### PR TITLE
Implement iterative speed profile solver with dynamic constraints

### DIFF
--- a/src/speed_solver.py
+++ b/src/speed_solver.py
@@ -1,0 +1,114 @@
+r"""Speed profile solver for a predefined path.
+
+This module computes the maximum speed profile along a path described by an
+``s``-grid and curvature :math:`\kappa(s)`.  The solver enforces lateral
+acceleration limits via a friction ellipse and accounts for additional
+longitudinal constraints such as wheelies and stoppies.  The algorithm performs
+iterative forward and backward passes updating the speed until convergence.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import numpy as np
+
+
+def solve_speed_profile(
+    s: Iterable[float],
+    kappa: Iterable[float],
+    mu: float,
+    a_wheelie_max: float,
+    a_brake: float,
+    v_init: Iterable[float] | None = None,
+    g: float = 9.81,
+    max_iterations: int = 50,
+    tol: float = 1e-3,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    r"""Solve for the feasible speed profile along a path.
+
+    Parameters
+    ----------
+    s:
+        Arc-length positions along the path.
+    kappa:
+        Curvature :math:`\kappa` at each ``s``.
+    mu:
+        Tyre-road friction coefficient.
+    a_wheelie_max:
+        Maximum longitudinal acceleration before a wheelie occurs.
+    a_brake:
+        Maximum braking deceleration before a stoppie occurs.  This also
+        defines the longitudinal limit of the friction ellipse in braking.
+    v_init:
+        Optional initial guess for the speed profile.  If ``None`` a profile
+        based on the lateral acceleration limit ``mu * g`` is used.
+    g:
+        Gravitational acceleration in ``m/s^2``.
+    max_iterations:
+        Maximum number of forward/backward passes.
+    tol:
+        Convergence tolerance on the change in speed between iterations.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        Arrays of speed ``v``, longitudinal acceleration ``ax`` and lateral
+        acceleration ``ay`` sampled at ``s``.
+    """
+    s = np.asarray(s, dtype=float)
+    kappa = np.asarray(kappa, dtype=float)
+    if s.shape != kappa.shape:
+        raise ValueError("s and kappa must have the same shape")
+    if s.ndim != 1:
+        raise ValueError("s and kappa must be one-dimensional")
+    if np.any(np.diff(s) <= 0):
+        raise ValueError("s must be strictly increasing")
+
+    n = s.size
+    ds = np.diff(s)
+
+    if v_init is None:
+        # Initial guess limited only by lateral grip.
+        v = np.empty_like(s)
+        mask = np.abs(kappa) > 1e-9
+        v[mask] = np.sqrt(mu * g / np.abs(kappa[mask]))
+        v[~mask] = 1e3
+    else:
+        v = np.asarray(v_init, dtype=float)
+        if v.shape != s.shape:
+            raise ValueError("v_init must have the same shape as s")
+    # Enforce boundary conditions of starting and ending at rest.
+    v[0] = 0.0
+    v[-1] = 0.0
+
+    mu_g = mu * g
+    for _ in range(max_iterations):
+        v_prev = v.copy()
+        ay = v**2 * kappa
+
+        # Longitudinal acceleration limits from friction ellipse.
+        ay_sq = ay**2
+        ax_friction = np.sqrt(np.maximum(mu_g**2 - ay_sq, 0.0))
+        ax_max = np.minimum(ax_friction, a_wheelie_max)
+        ax_min = -np.minimum(np.sqrt(np.maximum(a_brake**2 - ay_sq, 0.0)), a_brake)
+
+        # Forward pass (acceleration)
+        for i in range(n - 1):
+            v_next = np.sqrt(max(v[i] ** 2 + 2.0 * ax_max[i] * ds[i], 0.0))
+            if v_next < v[i + 1]:
+                v[i + 1] = v_next
+        # Backward pass (braking)
+        for i in range(n - 1, 0, -1):
+            v_prev_allowed = np.sqrt(
+                max(v[i] ** 2 - 2.0 * ax_min[i - 1] * ds[i - 1], 0.0)
+            )
+            if v_prev_allowed < v[i - 1]:
+                v[i - 1] = v_prev_allowed
+
+        if np.max(np.abs(v - v_prev)) < tol:
+            break
+
+    ay = v**2 * kappa
+    ax = 0.5 * np.gradient(v**2, s, edge_order=2)
+    return v, ax, ay

--- a/tests/test_speed_solver.py
+++ b/tests/test_speed_solver.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Add the ``src`` directory to the import path for test execution.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from speed_solver import solve_speed_profile
+
+
+def test_straight_line_profile() -> None:
+    s = np.linspace(0.0, 100.0, 11)
+    kappa = np.zeros_like(s)
+    v, ax, ay = solve_speed_profile(
+        s,
+        kappa,
+        mu=1.2,
+        a_wheelie_max=9.81,
+        a_brake=11.772,
+    )
+    assert v.shape == s.shape
+    assert np.allclose(ay, 0.0)
+    mid = len(s) // 2
+    expected_vmax = np.sqrt(9.81 * 100.0)
+    assert np.isclose(v[mid], expected_vmax, atol=0.5)
+    assert np.isclose(v[0], 0.0, atol=1e-6)
+    assert np.isclose(v[-1], 0.0, atol=1e-6)
+    assert np.isclose(ax[1], 9.81, rtol=1e-2)
+    assert np.isclose(ax[-2], -11.772, rtol=1e-2)


### PR DESCRIPTION
## Summary
- add `speed_solver.solve_speed_profile` to compute velocity and acceleration along a path
- incorporate friction ellipse plus wheelie and stoppie limits with iterative forward/backward passes
- test solver on a straight path with acceleration and braking limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf11b510832ab3b2c68df0326efd