### PR TITLE
Add I/O utilities and demo CLI

### DIFF
--- a/src/io_utils.py
+++ b/src/io_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Utility functions for reading and writing CSV data.
+
+This module centralises basic I/O helpers used by the demo script.  It
+provides convenience wrappers around :mod:`pandas` for loading track
+layouts and saving results as well as a light-weight parser for the bike
+parameter CSV files used by :class:`~src.vehicle.Vehicle` and the speed
+solver.
+"""
+
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+import csv
+import pandas as pd
+
+
+def read_track_csv(path: str | Path) -> pd.DataFrame:
+    """Read a track layout CSV into a :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    path:
+        Location of the CSV file describing the track.
+    """
+    return pd.read_csv(path)
+
+
+def read_bike_params_csv(path: str | Path) -> Dict[str, float]:
+    """Read motorcycle parameters from ``path``.
+
+    The parameter files are simple ``key,value`` CSVs.  A section starting
+    with a row whose first entry is ``rpm`` (used for torque curves) is
+    ignored by this helper as it is not required for the speed solver.
+    """
+    params: Dict[str, float] = {}
+    with Path(path).open(newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row or all(cell.strip() == "" for cell in row):
+                continue
+            key = row[0].strip()
+            if key.lower() == "rpm":
+                break
+            try:
+                params[key] = float(row[1])
+            except (IndexError, ValueError):
+                continue
+    return params
+
+
+def write_csv(data: Mapping[str, Iterable] | pd.DataFrame, file_path: str | Path) -> None:
+    """Write ``data`` to ``file_path`` ensuring parent directories exist."""
+    file_path = Path(file_path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(data, pd.DataFrame):
+        data.to_csv(file_path, index=False)
+    else:
+        pd.DataFrame(data).to_csv(file_path, index=False)

--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -12,7 +12,14 @@ from typing import Iterable, Sequence
 import numpy as np
 from scipy.optimize import minimize, NonlinearConstraint
 
-from path_param import LateralOffsetSpline, path_curvature
+# ``path_optim`` can be imported either as part of the ``src`` package or as a
+# stand-alone module.  The ``try``/``except`` block below supports both usages
+# by attempting a relative import first and falling back to an absolute import
+# if that fails.
+try:  # pragma: no cover - import shim
+    from .path_param import LateralOffsetSpline, path_curvature
+except ImportError:  # pragma: no cover - direct execution support
+    from path_param import LateralOffsetSpline, path_curvature
 
 
 def optimise_lateral_offset(

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Command line demo for the lap-time optimisation pipeline.
+
+Running ``python -m src.run_demo`` executes a simple workflow that
+parses a track layout, optimises a racing line and computes a feasible
+speed profile.  Results are written to time-stamped CSV files under the
+``outputs`` directory.
+"""
+
+from pathlib import Path
+from datetime import datetime
+import argparse
+
+import numpy as np
+import pandas as pd
+
+from .io_utils import read_track_csv, read_bike_params_csv, write_csv
+from .geometry import load_track
+from .path_optim import optimise_lateral_offset
+from .path_param import path_curvature
+from .speed_solver import solve_speed_profile
+
+
+def run(track_file: str, bike_file: str, ds: float, buffer: float, n_ctrl: int) -> Path:
+    """Execute the optimisation pipeline and return the output directory."""
+    # Load input data
+    read_track_csv(track_file)  # ensure the file exists and is readable
+    bike_params = read_bike_params_csv(bike_file)
+
+    x, y, psi, kappa_c, left_edge, right_edge = load_track(track_file, ds)
+    s = np.arange(x.size) * ds
+
+    # Path optimisation
+    s_control = np.linspace(s[0], s[-1], n_ctrl)
+    offset_spline = optimise_lateral_offset(
+        s, kappa_c, left_edge, right_edge, s_control, buffer=buffer
+    )
+    offset = offset_spline(s)
+    kappa_path = path_curvature(s, offset_spline, kappa_c)
+    normal_x = -np.sin(psi)
+    normal_y = np.cos(psi)
+    x_path = x + offset * normal_x
+    y_path = y + offset * normal_y
+
+    # Speed solver
+    mu = float(bike_params.get("mu", 1.0))
+    a_wheelie_max = float(bike_params.get("a_wheelie_max", 9.81))
+    a_brake = float(bike_params.get("a_brake", 9.81))
+    v, ax, ay = solve_speed_profile(s, kappa_path, mu, a_wheelie_max, a_brake)
+
+    # Write outputs
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = Path("outputs") / timestamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    geometry_df = pd.DataFrame(
+        {
+            "s_m": s,
+            "x_center_m": x,
+            "y_center_m": y,
+            "heading_rad": psi,
+            "curvature_1pm": kappa_c,
+            "x_left_m": left_edge[:, 0],
+            "y_left_m": left_edge[:, 1],
+            "x_right_m": right_edge[:, 0],
+            "y_right_m": right_edge[:, 1],
+        }
+    )
+    results_df = pd.DataFrame(
+        {
+            "s_m": s,
+            "x_path_m": x_path,
+            "y_path_m": y_path,
+            "offset_m": offset,
+            "curvature_1pm": kappa_path,
+            "speed_mps": v,
+            "ax_mps2": ax,
+            "ay_mps2": ay,
+        }
+    )
+
+    write_csv(geometry_df, out_dir / "geometry.csv")
+    write_csv(results_df, out_dir / "results.csv")
+    return out_dir
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run lap-time optimisation demo")
+    parser.add_argument("--track", default="data/track_layout.csv", help="Track layout CSV")
+    parser.add_argument("--bike", default="data/bike_params_sv650.csv", help="Bike parameter CSV")
+    parser.add_argument("--ds", type=float, default=1.0, help="Track interpolation spacing")
+    parser.add_argument("--buffer", type=float, default=0.5, help="Track edge buffer")
+    parser.add_argument(
+        "--ctrl-points", type=int, default=20, help="Number of lateral offset control points"
+    )
+    args = parser.parse_args(argv)
+
+    out_dir = run(args.track, args.bike, args.ds, args.buffer, args.ctrl_points)
+    print(f"Outputs written to {out_dir}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add reusable CSV helpers for track, bike and outputs
- provide `run_demo` CLI to execute geometry parsing, path optimisation and speed solver
- make path optimisation imports package-friendly

## Testing
- `pytest -q`
- `python -m src.run_demo --track data/track_layout.csv --bike data/bike_params_sv650.csv --ds 5.0 --buffer 0.5 --ctrl-points 10`


------
https://chatgpt.com/codex/tasks/task_e_68b8d006c614832ab21bc60cc2513683