### PR TITLE
Add track layout loader with geometry dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ python -m src.run_demo --track data/track_layout.csv --bike data/bike_params_r6.
 
 Replace `track_layout.csv` and `bike_params_r6.csv` with the desired files.
 
+The track layout file follows the ``track_layout.csv`` format where each row
+describes the start of either a straight or constant-radius corner section. The
+columns ``x_m``, ``y_m``, ``section_type`` and ``radius_m`` define the geometry
+while ``width_m`` gives the track width used to compute the left and right
+edges.
+
 ## License
 
 MIT License (to be defined).

--- a/src/geometry.py
+++ b/src/geometry.py
@@ -1,16 +1,39 @@
 """Track geometry utilities.
 
-This module provides functionality to load a track layout from a CSV file and
-interpolate the centreline onto a uniform arc-length grid. The track width is
-used to compute coordinates of the left and right boundaries.
+This module provides helpers for working with two simple track layout
+descriptions:
+
+``load_track``
+    Legacy helper that interpolates a centreline defined by arbitrary nodes on
+    to a uniform arc-length grid.
+``load_track_layout``
+    Parser for the more structured ``track_layout.csv`` format used by the
+    command line demo.  Each consecutive row describes either a straight or a
+    constant-radius corner which is discretised at the requested spacing.
+
+The :func:`load_track_layout` function returns a :class:`TrackGeometry`
+dataclass bundling the centreline and track-edge coordinates.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
+
+
+@dataclass
+class TrackGeometry:
+    """Discrete representation of a race track."""
+
+    x: np.ndarray
+    y: np.ndarray
+    heading: np.ndarray
+    curvature: np.ndarray
+    left_edge: np.ndarray
+    right_edge: np.ndarray
 
 
 def load_track(file_path: str, ds: float) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -76,3 +99,102 @@ def load_track(file_path: str, ds: float) -> Tuple[np.ndarray, np.ndarray, np.nd
     right_edge = np.column_stack((x_right, y_right))
 
     return x_s, y_s, heading, curvature, left_edge, right_edge
+
+
+def load_track_layout(path: str, ds: float) -> TrackGeometry:
+    """Load a structured ``track_layout.csv`` file.
+
+    Parameters
+    ----------
+    path:
+        Location of the CSV file describing the track layout.  Each row marks
+        the beginning of a segment.  The ``section_type`` column selects either
+        ``"straight"`` or ``"corner"`` and ``radius_m`` gives the signed corner
+        radius.
+    ds:
+        Desired arc-length spacing for discretisation.
+
+    Returns
+    -------
+    TrackGeometry
+        Dataclass containing the sampled centreline and track boundaries.
+    """
+    if ds <= 0:
+        raise ValueError("ds must be positive")
+
+    df = pd.read_csv(path)
+    x_nodes = df["x_m"].to_numpy(float)
+    y_nodes = df["y_m"].to_numpy(float)
+    width_nodes = df["width_m"].to_numpy(float)
+    radius_nodes = df.get("radius_m", pd.Series(0.0, index=df.index)).to_numpy(float)
+    section_types = df["section_type"].astype(str).to_numpy()
+
+    x_list: list[np.ndarray] = []
+    y_list: list[np.ndarray] = []
+    heading_list: list[np.ndarray] = []
+    curvature_list: list[np.ndarray] = []
+    width_list: list[np.ndarray] = []
+
+    n = len(df)
+    for i in range(n):
+        x0, y0 = x_nodes[i], y_nodes[i]
+        x1, y1 = x_nodes[(i + 1) % n], y_nodes[(i + 1) % n]
+        w0, w1 = width_nodes[i], width_nodes[(i + 1) % n]
+        seg_type = section_types[i].lower()
+
+        if seg_type == "straight":
+            dx, dy = x1 - x0, y1 - y0
+            seg_len = float(np.hypot(dx, dy))
+            s_local = np.arange(0.0, seg_len, ds)
+            if i != 0:
+                s_local = s_local[1:]
+            ratio = s_local / seg_len
+            x_seg = x0 + ratio * dx
+            y_seg = y0 + ratio * dy
+            heading_seg = np.full_like(x_seg, np.arctan2(dy, dx))
+            curvature_seg = np.zeros_like(x_seg)
+            width_seg = w0 + ratio * (w1 - w0)
+        elif seg_type == "corner":
+            r = radius_nodes[i]
+            if r == 0:
+                raise ValueError("corner segment requires non-zero radius")
+            v = np.array([x1 - x0, y1 - y0], dtype=float)
+            chord = float(np.hypot(*v))
+            mid = np.array([x0 + x1, y0 + y1], dtype=float) / 2.0
+            perp = np.array([-v[1], v[0]]) / chord
+            h = np.sqrt(r**2 - (chord / 2.0) ** 2)
+            centre = mid + np.sign(r) * perp * h
+            phi0 = np.arctan2(y0 - centre[1], x0 - centre[0])
+            theta = 2.0 * np.arcsin(chord / (2.0 * abs(r))) * np.sign(r)
+            seg_len = abs(r * theta)
+            s_local = np.arange(0.0, seg_len, ds)
+            if i != 0:
+                s_local = s_local[1:]
+            phi = phi0 + s_local / r
+            x_seg = centre[0] + r * np.cos(phi)
+            y_seg = centre[1] + r * np.sin(phi)
+            heading_seg = phi + np.sign(r) * (np.pi / 2.0)
+            curvature_seg = np.full_like(x_seg, 1.0 / r)
+            width_seg = w0 + (w1 - w0) * (s_local / seg_len)
+        else:
+            raise ValueError(f"unknown section_type '{section_types[i]}'")
+
+        x_list.append(x_seg)
+        y_list.append(y_seg)
+        heading_list.append(heading_seg)
+        curvature_list.append(curvature_seg)
+        width_list.append(width_seg)
+
+    x = np.concatenate(x_list)
+    y = np.concatenate(y_list)
+    heading = np.concatenate(heading_list)
+    curvature = np.concatenate(curvature_list)
+    width = np.concatenate(width_list)
+
+    half_width = 0.5 * width
+    normal_x = -np.sin(heading)
+    normal_y = np.cos(heading)
+    left_edge = np.column_stack((x + half_width * normal_x, y + half_width * normal_y))
+    right_edge = np.column_stack((x - half_width * normal_x, y - half_width * normal_y))
+
+    return TrackGeometry(x, y, heading, curvature, left_edge, right_edge)

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 from .io_utils import read_track_csv, read_bike_params_csv, write_csv
-from .geometry import load_track
+from .geometry import load_track_layout
 from .path_optim import optimise_lateral_offset
 from .path_param import path_curvature
 from .speed_solver import solve_speed_profile
@@ -28,7 +28,9 @@ def run(track_file: str, bike_file: str, ds: float, buffer: float, n_ctrl: int) 
     read_track_csv(track_file)  # ensure the file exists and is readable
     bike_params = read_bike_params_csv(bike_file)
 
-    x, y, psi, kappa_c, left_edge, right_edge = load_track(track_file, ds)
+    geom = load_track_layout(track_file, ds)
+    x, y, psi, kappa_c = geom.x, geom.y, geom.heading, geom.curvature
+    left_edge, right_edge = geom.left_edge, geom.right_edge
     s = np.arange(x.size) * ds
 
     # Path optimisation

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -7,26 +7,28 @@ import pandas as pd
 # Ensure src directory on path for test discovery when pytest runs directly
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from geometry import load_track
+from geometry import load_track_layout
 
 
 def test_circle_track_length_and_curvature(tmp_path: Path) -> None:
     R = 50.0
-    theta = np.linspace(0.0, 2 * np.pi, 100, endpoint=False)
-    df = pd.DataFrame(
-        {
-            "x_m": R * np.cos(theta),
-            "y_m": R * np.sin(theta),
-            "width_m": np.full(theta.shape, 10.0),
-        }
-    )
+    data = [
+        {"x_m": R, "y_m": 0.0, "section_type": "corner", "radius_m": R, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": 0.0, "y_m": R, "section_type": "corner", "radius_m": R, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": -R, "y_m": 0.0, "section_type": "corner", "radius_m": R, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": 0.0, "y_m": -R, "section_type": "corner", "radius_m": R, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+    ]
+    df = pd.DataFrame(data)
     track_file = tmp_path / "circle.csv"
     df.to_csv(track_file, index=False)
 
-    x, y, heading, curvature, left, right = load_track(track_file, ds=1.0)
+    geom = load_track_layout(track_file, ds=1.0)
 
-    length = np.sum(
-        np.hypot(np.diff(np.r_[x, x[0]]), np.diff(np.r_[y, y[0]]))
-    )
+    x, y = geom.x, geom.y
+    length = np.sum(np.hypot(np.diff(np.r_[x, x[0]]), np.diff(np.r_[y, y[0]])))
     assert np.isclose(length, 2 * np.pi * R, atol=1.0)
-    assert np.all(curvature > -1e-6)
+    assert np.allclose(geom.curvature, 1.0 / R, atol=1e-2)

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -6,21 +6,21 @@ import numpy as np
 # Add the ``src`` directory to the import path for test execution.
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from geometry import load_track
+from geometry import load_track_layout
 from path_optim import optimise_lateral_offset
 
 
 def test_optimisation_respects_bounds():
-    x, y, heading, curvature, left, right = load_track(
-        "data/track_layout.csv", ds=10.0
-    )
-    s = np.arange(len(x)) * 10.0
+    geom = load_track_layout("data/track_layout.csv", ds=10.0)
+    s = np.arange(len(geom.x)) * 10.0
     s_control = np.linspace(s[0], s[-1], 8)
 
-    offset = optimise_lateral_offset(s, curvature, left, right, s_control, buffer=0.5)
+    offset = optimise_lateral_offset(
+        s, geom.curvature, geom.left_edge, geom.right_edge, s_control, buffer=0.5
+    )
 
     e_vals = offset(s)
-    half_width = 0.5 * np.linalg.norm(left - right, axis=1) - 0.5
+    half_width = 0.5 * np.linalg.norm(geom.left_edge - geom.right_edge, axis=1) - 0.5
 
     assert np.all(e_vals <= half_width + 1e-6)
     assert np.all(e_vals >= -half_width - 1e-6)


### PR DESCRIPTION
## Summary
- implement `load_track_layout` that parses straights and constant-radius corners
- return sampled geometry via new `TrackGeometry` dataclass
- update demo, tests, and documentation for new track layout format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8da4008e8832a9a0d5e7562547d4c