### PR TITLE
Fix negative-radius corner handling in geometry

### DIFF
--- a/src/geometry.py
+++ b/src/geometry.py
@@ -158,21 +158,22 @@ def load_track_layout(path: str, ds: float) -> TrackGeometry:
             r = radius_nodes[i]
             if r == 0:
                 raise ValueError("corner segment requires non-zero radius")
+            R = abs(r)
             v = np.array([x1 - x0, y1 - y0], dtype=float)
             chord = float(np.hypot(*v))
             mid = np.array([x0 + x1, y0 + y1], dtype=float) / 2.0
             perp = np.array([-v[1], v[0]]) / chord
-            h = np.sqrt(r**2 - (chord / 2.0) ** 2)
+            h = np.sqrt(R**2 - (chord / 2.0) ** 2)
             centre = mid + np.sign(r) * perp * h
             phi0 = np.arctan2(y0 - centre[1], x0 - centre[0])
-            theta = 2.0 * np.arcsin(chord / (2.0 * abs(r))) * np.sign(r)
-            seg_len = abs(r * theta)
+            theta = 2.0 * np.arcsin(chord / (2.0 * R)) * np.sign(r)
+            seg_len = abs(R * theta)
             s_local = np.arange(0.0, seg_len, ds)
             if i != 0:
                 s_local = s_local[1:]
             phi = phi0 + s_local / r
-            x_seg = centre[0] + r * np.cos(phi)
-            y_seg = centre[1] + r * np.sin(phi)
+            x_seg = centre[0] + R * np.cos(phi)
+            y_seg = centre[1] + R * np.sin(phi)
             heading_seg = phi + np.sign(r) * (np.pi / 2.0)
             curvature_seg = np.full_like(x_seg, 1.0 / r)
             width_seg = w0 + (w1 - w0) * (s_local / seg_len)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -32,3 +32,30 @@ def test_circle_track_length_and_curvature(tmp_path: Path) -> None:
     length = np.sum(np.hypot(np.diff(np.r_[x, x[0]]), np.diff(np.r_[y, y[0]])))
     assert np.isclose(length, 2 * np.pi * R, atol=1.0)
     assert np.allclose(geom.curvature, 1.0 / R, atol=1e-2)
+
+
+def test_right_hand_corner_continuity(tmp_path: Path) -> None:
+    data = [
+        {"x_m": 0.0, "y_m": 0.0, "section_type": "straight", "radius_m": 0.0, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": 10.0, "y_m": 0.0, "section_type": "corner", "radius_m": -5.0, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": 10.0, "y_m": -10.0, "section_type": "straight", "radius_m": 0.0, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+        {"x_m": 0.0, "y_m": -10.0, "section_type": "corner", "radius_m": -5.0, "width_m": 10.0,
+         "camber_rad": 0.0, "grade_rad": 0.0},
+    ]
+    df = pd.DataFrame(data)
+    track_file = tmp_path / "right_hand.csv"
+    df.to_csv(track_file, index=False)
+
+    geom = load_track_layout(track_file, ds=1.0)
+
+    node = np.array([data[1]["x_m"], data[1]["y_m"]])
+    curvature = geom.curvature
+    idx = np.where(curvature != 0)[0][0]
+    corner_pt = np.array([geom.x[idx], geom.y[idx]])
+    prev_pt = np.array([geom.x[idx - 1], geom.y[idx - 1]])
+
+    assert np.isclose(np.linalg.norm(corner_pt - node), 1.0, atol=5e-3)
+    assert np.isclose(np.linalg.norm(prev_pt - node), 1.0, atol=5e-3)


### PR DESCRIPTION
## Summary
- handle negative-radius corners by using their absolute radius for geometry calculations
- add regression test for right-hand corner continuity

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8de2103ec832a8355f391c3ba2cba