### PR TITLE
Add closed-loop iteration to speed solver

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -49,7 +49,10 @@ def run(track_file: str, bike_file: str, ds: float, buffer: float, n_ctrl: int) 
     mu = float(bike_params.get("mu", 1.0))
     a_wheelie_max = float(bike_params.get("a_wheelie_max", 9.81))
     a_brake = float(bike_params.get("a_brake", 9.81))
-    v, ax, ay = solve_speed_profile(s, kappa_path, mu, a_wheelie_max, a_brake)
+    closed = np.hypot(x[0] - x[-1], y[0] - y[-1]) <= ds
+    v, ax, ay = solve_speed_profile(
+        s, kappa_path, mu, a_wheelie_max, a_brake, closed_loop=closed
+    )
 
     # Write outputs
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Summary
- allow solving speed profiles on closed-loop tracks by iterating start/end speeds until convergence
- detect closed tracks in demo and pass `closed_loop=True`
- test closed circular track convergence and peak speed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e58e4938832a8e801765742d2812