### PR TITLE
Refine closed-loop speed solver and tests

### DIFF
--- a/src/speed_solver.py
+++ b/src/speed_solver.py
@@ -71,13 +71,8 @@ def solve_speed_profile(
 
     n = s.size
     ds = np.diff(s)
-    if closed_loop:
-        # Estimate the segment length connecting the last point back to the
-        # start to close the loop.  The grid is assumed to have approximately
-        # uniform spacing so the first step is representative.
-        if n < 2:
-            raise ValueError("closed loop requires at least two points")
-        ds_wrap = float(s[1] - s[0])
+    if closed_loop and n < 2:
+        raise ValueError("closed loop requires at least two points")
 
     if v_init is None:
         # Initial guess limited only by lateral grip.
@@ -105,42 +100,27 @@ def solve_speed_profile(
         ax_max = np.minimum(ax_friction, a_wheelie_max)
         ax_min = -np.minimum(np.sqrt(np.maximum(a_brake**2 - ay_sq, 0.0)), a_brake)
 
-        if closed_loop:
-            # Forward pass across the wrap-around segment
-            for i in range(n):
-                j = (i + 1) % n
-                seg_len = ds[i] if i < n - 1 else ds_wrap
-                v_next = np.sqrt(max(v[i] ** 2 + 2.0 * ax_max[i] * seg_len, 0.0))
-                if v_next < v[j]:
-                    v[j] = v_next
-            # Backward pass across the wrap-around segment
-            for i in range(n - 1, -1, -1):
-                j = (i - 1) % n
-                seg_len = ds[j] if j < n - 1 else ds_wrap
-                v_prev_allowed = np.sqrt(
-                    max(v[i] ** 2 - 2.0 * ax_min[j] * seg_len, 0.0)
-                )
-                if v_prev_allowed < v[j]:
-                    v[j] = v_prev_allowed
-        else:
-            # Forward pass (acceleration)
-            for i in range(n - 1):
-                v_next = np.sqrt(max(v[i] ** 2 + 2.0 * ax_max[i] * ds[i], 0.0))
-                if v_next < v[i + 1]:
-                    v[i + 1] = v_next
-            # Backward pass (braking)
-            for i in range(n - 1, 0, -1):
-                v_prev_allowed = np.sqrt(
-                    max(v[i] ** 2 - 2.0 * ax_min[i - 1] * ds[i - 1], 0.0)
-                )
-                if v_prev_allowed < v[i - 1]:
-                    v[i - 1] = v_prev_allowed
+        # Forward pass (acceleration)
+        for i in range(n - 1):
+            v_next = np.sqrt(max(v[i] ** 2 + 2.0 * ax_max[i] * ds[i], 0.0))
+            if v_next < v[i + 1]:
+                v[i + 1] = v_next
+        # Backward pass (braking)
+        for i in range(n - 1, 0, -1):
+            v_prev_allowed = np.sqrt(
+                max(v[i] ** 2 - 2.0 * ax_min[i - 1] * ds[i - 1], 0.0)
+            )
+            if v_prev_allowed < v[i - 1]:
+                v[i - 1] = v_prev_allowed
 
         if closed_loop:
             v_edge = 0.5 * (v[0] + v[-1])
             v[0] = v[-1] = v_edge
-        if np.max(np.abs(v - v_prev)) < tol:
-            break
+            if max(abs(v[0] - v_prev[0]), abs(v[-1] - v_prev[-1])) < tol:
+                break
+        else:
+            if np.max(np.abs(v - v_prev)) < tol:
+                break
     ay = v**2 * kappa
     ax = 0.5 * np.gradient(v**2, s, edge_order=2)
     return v, ax, ay

--- a/tests/test_speed_solver.py
+++ b/tests/test_speed_solver.py
@@ -67,10 +67,10 @@ def test_closed_circular_track_convergence() -> None:
     )
     assert np.isclose(v[0], v[-1], atol=1e-3)
     # Speeds should vary around the lap on a closed loop.
-    assert np.ptp(v) > 1.0
+    assert np.ptp(v) > 5.0
     straight = np.isclose(geom.curvature, 0.0)
     # Ensure the track contains straight sections and that the solver applies
     # acceleration or braking on them.
     assert straight.any()
-    assert not np.allclose(ax[straight], 0.0)
+    assert np.any(np.abs(ax[straight]) > 0.1)
     assert np.isclose(v.max(), 50.0, atol=15.0)


### PR DESCRIPTION
## Summary
- Simplified closed-loop speed profile solver by removing wrap-around index logic
- Enforced equality of start and end speeds via averaging and convergence on edge samples
- Strengthened tests to ensure speed variation and non-zero acceleration on straight track sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7cf5904832a834e934513036115