### PR TITLE
Add gear and limit tracking to demo

### DIFF
--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -11,7 +11,7 @@ from src.run_demo import run
 
 
 def test_one_corner_track_open_track() -> None:
-    out_dir = run(
+    lap_time, out_dir = run(
         "data/oneCornerTrack.csv",
         "data/bike_params_sv650.csv",
         ds=1.0,
@@ -19,6 +19,7 @@ def test_one_corner_track_open_track() -> None:
         n_ctrl=20,
         closed=False,
     )
+    assert lap_time > 0
     geom = pd.read_csv(out_dir / "geometry.csv")
     x = geom["x_center_m"].to_numpy()
     y = geom["y_center_m"].to_numpy()

--- a/tests/test_speed_solver.py
+++ b/tests/test_speed_solver.py
@@ -14,7 +14,7 @@ from io_utils import read_bike_params_csv
 def test_straight_line_profile() -> None:
     s = np.linspace(0.0, 100.0, 11)
     kappa = np.zeros_like(s)
-    v, ax, ay = solve_speed_profile(
+    v, ax, ay, limit = solve_speed_profile(
         s,
         kappa,
         mu=1.2,
@@ -24,6 +24,7 @@ def test_straight_line_profile() -> None:
         v_end=0.0,
     )
     assert v.shape == s.shape
+    assert limit.shape == s.shape
     assert np.allclose(ay, 0.0)
     mid = len(s) // 2
     expected_vmax = np.sqrt(9.81 * 100.0)
@@ -39,7 +40,7 @@ def test_straight_line_low_initial_speed_accelerates() -> None:
     kappa = np.zeros_like(s)
     v_init = np.zeros_like(s)
     v_init_orig = v_init.copy()
-    v, ax, ay = solve_speed_profile(
+    v, ax, ay, limit = solve_speed_profile(
         s,
         kappa,
         mu=1.2,
@@ -64,7 +65,7 @@ def test_circular_track_speed_limit() -> None:
     kappa[:200] = 0.0
     kappa[-200:] = 0.0
     mu = 1.2
-    v, ax, ay = solve_speed_profile(
+    v, ax, ay, limit = solve_speed_profile(
         s,
         kappa,
         mu=mu,
@@ -74,6 +75,7 @@ def test_circular_track_speed_limit() -> None:
     expected = np.sqrt(mu * 9.81 * R)
     mid = len(s) // 2
     assert np.isclose(v[mid], expected, atol=0.5)
+    assert limit[mid] == "corner"
 
 
 def test_closed_circular_track_convergence() -> None:
@@ -81,7 +83,7 @@ def test_closed_circular_track_convergence() -> None:
     geom = load_track_layout(str(base_path / "data" / "track_layout.csv"), ds=1.0)
     params = read_bike_params_csv(base_path / "data" / "bike_params_r6.csv")
     s = np.arange(geom.x.size)
-    v, ax, ay = solve_speed_profile(
+    v, ax, ay, limit = solve_speed_profile(
         s,
         geom.curvature,
         mu=params["mu"],
@@ -105,7 +107,7 @@ def test_open_track_has_free_end_speeds() -> None:
     geom = load_track_layout(base_path / "data" / "oneCornerTrack.csv", ds=1.0, closed=False)
     params = read_bike_params_csv(base_path / "data" / "bike_params_r6.csv")
     s = np.arange(geom.x.size)
-    v, ax, ay = solve_speed_profile(
+    v, ax, ay, limit = solve_speed_profile(
         s,
         geom.curvature,
         mu=params["mu"],


### PR DESCRIPTION
## Summary
- parse drivetrain and gear data in demo, compute engine RPM and gear selections
- expose limiting-factor classification from `solve_speed_profile`
- write speed in kph, gear, RPM and limit into results and report lap time

## Testing
- `pytest`
- `python -m src.run_demo --track data/oneCornerTrack.csv --bike data/bike_params_sv650.csv --ds 1.0 --buffer 0.5 --ctrl-points 20 --open`

------
https://chatgpt.com/codex/tasks/task_e_68b90cdf3da8832abc65a563bcca8aee