### PR TITLE
Track limiter sources and return lap time

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -82,7 +82,7 @@ def run(
                 return i + 1
         return 1
 
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s, kappa_path, mu, a_wheelie_max, a_brake, closed_loop=closed
     )
 
@@ -129,9 +129,6 @@ def run(
     write_csv(geometry_df, out_dir / "geometry.csv")
     write_csv(results_df, out_dir / "results.csv")
 
-    ds_arr = np.diff(s)
-    v_avg = 0.5 * (v[:-1] + v[1:])
-    lap_time = float(np.sum(ds_arr / np.maximum(v_avg, 1e-9)))
     return lap_time, out_dir
 
 

--- a/tests/test_speed_solver.py
+++ b/tests/test_speed_solver.py
@@ -14,7 +14,7 @@ from io_utils import read_bike_params_csv
 def test_straight_line_profile() -> None:
     s = np.linspace(0.0, 100.0, 11)
     kappa = np.zeros_like(s)
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s,
         kappa,
         mu=1.2,
@@ -40,7 +40,7 @@ def test_straight_line_low_initial_speed_accelerates() -> None:
     kappa = np.zeros_like(s)
     v_init = np.zeros_like(s)
     v_init_orig = v_init.copy()
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s,
         kappa,
         mu=1.2,
@@ -65,7 +65,7 @@ def test_circular_track_speed_limit() -> None:
     kappa[:200] = 0.0
     kappa[-200:] = 0.0
     mu = 1.2
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s,
         kappa,
         mu=mu,
@@ -83,7 +83,7 @@ def test_closed_circular_track_convergence() -> None:
     geom = load_track_layout(str(base_path / "data" / "track_layout.csv"), ds=1.0)
     params = read_bike_params_csv(base_path / "data" / "bike_params_r6.csv")
     s = np.arange(geom.x.size)
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s,
         geom.curvature,
         mu=params["mu"],
@@ -107,7 +107,7 @@ def test_open_track_has_free_end_speeds() -> None:
     geom = load_track_layout(base_path / "data" / "oneCornerTrack.csv", ds=1.0, closed=False)
     params = read_bike_params_csv(base_path / "data" / "bike_params_r6.csv")
     s = np.arange(geom.x.size)
-    v, ax, ay, limit = solve_speed_profile(
+    v, ax, ay, limit, lap_time = solve_speed_profile(
         s,
         geom.curvature,
         mu=params["mu"],


### PR DESCRIPTION
## Summary
- track active constraint for each segment during forward and backward speed passes
- expose lap time and limiting factor array from `solve_speed_profile`
- update demo and tests for new solver signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90ddcecb4832ab0c0e444f9507b78