### PR TITLE
Display lap time before output directory

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -167,7 +167,7 @@ def main(argv: list[str] | None = None) -> None:
         args.ctrl_points,
         closed=args.closed,
     )
-    print(f"Lap time: {lap_time:.3f} s")
+    print(f"Lap time: {lap_time:.2f} s")
     print(f"Outputs written to {out_dir}")
 
 


### PR DESCRIPTION
## Summary
- Print lap time with two-decimal precision in demo CLI
- Preserve output message after lap time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90ee37734832aa562d907c5a34380