### PR TITLE
Add lap time summary output

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -11,6 +11,7 @@ speed profile.  Results are written to time-stamped CSV files under the
 from pathlib import Path
 from datetime import datetime
 import argparse
+import json
 
 import numpy as np
 import pandas as pd
@@ -122,6 +123,11 @@ def run(
 
     write_csv(geometry_df, out_dir / "geometry.csv")
     write_csv(results_df, out_dir / "results.csv")
+
+    # Store a simple summary so tests and consumers can easily access the
+    # overall lap time without parsing the full CSV results.
+    with (out_dir / "summary.json").open("w") as f:
+        json.dump({"lap_time_s": lap_time}, f)
 
     return lap_time, out_dir
 

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import json
 
 import numpy as np
 import pandas as pd
@@ -19,7 +20,13 @@ def test_one_corner_track_open_track() -> None:
         n_ctrl=20,
         closed=False,
     )
-    assert lap_time > 0
+
+    summary_path = out_dir / "summary.json"
+    assert summary_path.exists()
+    with summary_path.open() as f:
+        summary = json.load(f)
+    assert summary["lap_time_s"] > 0
+    assert np.isclose(summary["lap_time_s"], lap_time)
     geom = pd.read_csv(out_dir / "geometry.csv")
     x = geom["x_center_m"].to_numpy()
     y = geom["y_center_m"].to_numpy()


### PR DESCRIPTION
## Summary
- Record overall lap time in a new `summary.json` file when running the demo
- Verify the stored lap time is present and positive in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91152f9a8832a9278274efed57167