### PR TITLE
Add drivetrain tests for gear selection and RPM

### DIFF
--- a/src/drivetrain_utils.py
+++ b/src/drivetrain_utils.py
@@ -41,11 +41,17 @@ def select_gear(
     final_drive: float,
     rw: float,
 ) -> float:
-    """Return the highest gear ratio that keeps engine RPM below the shift point."""
-    for g in reversed(gears):
+    """Return the highest gear ratio that keeps engine RPM below ``shift_rpm``."""
+
+    # ``gears`` is expected to be ordered from lowest to highest gear number
+    # (i.e. highest to lowest ratio).  Iterate in this order and select the
+    # first gear whose engine speed does not exceed the shift point.  If the
+    # engine would exceed ``shift_rpm`` even in the highest gear, fall back to
+    # that top gear rather than an unrealistic first-gear default.
+    for g in gears:
         if engine_rpm(v_mps, primary, final_drive, g, rw) <= shift_rpm:
             return g
-    return gears[0]
+    return gears[-1]
 
 
 __all__ = ["engine_rpm", "select_gear"]

--- a/tests/test_drivetrain_utils.py
+++ b/tests/test_drivetrain_utils.py
@@ -1,0 +1,79 @@
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the ``src`` directory to the import path for test execution.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from drivetrain_utils import engine_rpm, select_gear
+
+
+def _load_params() -> tuple[dict[str, float], list[float]]:
+    """Load SV650 parameters and ordered gear ratios."""
+
+    params: dict[str, float] = {}
+    path = Path(__file__).resolve().parents[1] / "data" / "bike_params_sv650.csv"
+    with path.open(newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 2:
+                continue
+            try:
+                params[row[0]] = float(row[1])
+            except ValueError:
+                continue
+    gears = [params[f"gear{i}"] for i in range(1, 7)]
+    return params, gears
+
+
+def test_engine_rpm_known_value() -> None:
+    params, gears = _load_params()
+    rpm = engine_rpm(
+        30.0,
+        params["primary"],
+        params["final_drive"],
+        gears[2],  # third gear
+        params["rw"],
+    )
+    assert rpm == pytest.approx(8565.910961476091)
+
+
+@pytest.mark.parametrize(
+    "speed, expected_idx, expected_rpm",
+    [
+        (10.0, 0, 5089.559829348139),
+        (25.0, 1, 9189.483024637575),
+        (35.0, 2, 9993.562788388772),
+        (45.0, 3, 10467.395506442812),
+        (50.0, 4, 9940.546544603194),
+        (55.0, 5, 9687.246688945941),
+        # Even above ``shift_rpm`` the highest gear should be selected
+        (60.0, 5, 10567.905478850122),
+    ],
+)
+def test_select_gear(speed: float, expected_idx: int, expected_rpm: float) -> None:
+    params, gears = _load_params()
+    gear = select_gear(
+        speed,
+        gears,
+        params["shift_rpm"],
+        params["primary"],
+        params["final_drive"],
+        params["rw"],
+    )
+    assert gear == pytest.approx(gears[expected_idx])
+    rpm = engine_rpm(
+        speed,
+        params["primary"],
+        params["final_drive"],
+        gear,
+        params["rw"],
+    )
+    assert rpm == pytest.approx(expected_rpm)
+    if speed <= 55.0:
+        assert rpm <= params["shift_rpm"]
+    else:
+        assert rpm > params["shift_rpm"]
+


### PR DESCRIPTION
## Summary
- Correct gear selection to return the highest gear under shift RPM
- Add drivetrain utility tests covering engine RPM and gear selection edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b912a27054832abc7b3626db2c4a0f