### PR TITLE
Add flag to silence lap time printout

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Once implementation is complete, run simulations via the command line. Example:
 python -m src.run_demo --track data/track_layout.csv --bike data/bike_params_r6.csv
 ```
 
-Replace `track_layout.csv` and `bike_params_r6.csv` with the desired files.
+Replace `track_layout.csv` and `bike_params_r6.csv` with the desired files. By
+default, the command prints the simulated lap time; pass `--quiet-lap-time` to
+silence this summary output.
 
 The track layout file follows the ``track_layout.csv`` format where each row
 describes the start of either a straight or constant-radius corner section. The

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -157,6 +157,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Force track to be treated as closed",
     )
     parser.set_defaults(closed=None)
+    parser.add_argument(
+        "--quiet-lap-time",
+        action="store_true",
+        help="Suppress lap time output",
+    )
     args = parser.parse_args(argv)
 
     lap_time, out_dir = run(
@@ -167,7 +172,8 @@ def main(argv: list[str] | None = None) -> None:
         args.ctrl_points,
         closed=args.closed,
     )
-    print(f"Lap time: {lap_time:.2f} s")
+    if not args.quiet_lap_time:
+        print(f"Lap time: {lap_time:.2f} s")
     print(f"Outputs written to {out_dir}")
 
 


### PR DESCRIPTION
## Summary
- add `--quiet-lap-time` CLI flag to control lap time printing in `run_demo`
- document default lap-time output and quiet flag in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9149f25e0832a8b73f8ccb970d9ae