### PR TITLE
Sort torque curve by RPM before array conversion

### DIFF
--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -69,6 +69,11 @@ class Vehicle:
             torque_data = [(0.0, t_peak), (shift, t_peak)]
 
         self.params = params
+
+        # Ensure torque points are ordered by increasing RPM to avoid
+        # non-monotonic behaviour during interpolation.
+        torque_data.sort(key=lambda p: p[0])
+
         self.rpm = np.array([p[0] for p in torque_data], dtype=float)
         self.torque = np.array([p[1] for p in torque_data], dtype=float)
 


### PR DESCRIPTION
## Summary
- Ensure torque curve entries are sorted by RPM before converting to numpy arrays
- Guarantees monotonic data for reliable interpolation of tractive force curves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b917766cc4832aaf23ffad4d4684a1