### PR TITLE
Use np.trapz for backward compatibility

### DIFF
--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -90,7 +90,8 @@ def optimise_lateral_offset(
         kappa = path_curvature(s, spline, kappa_c)
         dkappa_ds = np.gradient(kappa, s, edge_order=2)
         integrand = kappa**2 + dkappa_ds**2
-        return float(np.trapezoid(integrand, s))
+        # np.trapz is used for backward compatibility.
+        return float(np.trapz(integrand, s))
 
     if method == "trust-constr":
         def eval_e(e_ctrl: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- Replace deprecated `np.trapezoid` with `np.trapz` in path optimisation objective
- Note usage of `np.trapz` to maintain backward compatibility with older NumPy versions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b917ea3424832a91992bd863ca4f63