### PR TITLE
Add inner/outer track boundaries and expose in outputs

### DIFF
--- a/src/plots.py
+++ b/src/plots.py
@@ -16,11 +16,12 @@ import matplotlib.pyplot as plt
 def plot_plan_view(
     x_center: Iterable[float],
     y_center: Iterable[float],
-    left_edge: np.ndarray,
-    right_edge: np.ndarray,
+    inner_edge: np.ndarray | None = None,
+    outer_edge: np.ndarray | None = None,
     x_path: Optional[Iterable[float]] = None,
     y_path: Optional[Iterable[float]] = None,
     ax: Optional[plt.Axes] = None,
+    **kwargs,
 ) -> plt.Axes:
     """Plot the track plan view.
 
@@ -28,20 +29,28 @@ def plot_plan_view(
     ----------
     x_center, y_center:
         Coordinates of the track centreline.
-    left_edge, right_edge:
+    inner_edge, outer_edge:
         Arrays of shape ``(N, 2)`` giving ``x`` and ``y`` coordinates of the
-        track boundaries.
+        inner and outer track boundaries.  ``left_edge``/``right_edge`` may be
+        supplied instead for backward compatibility.
     x_path, y_path:
         Optional coordinates of the racing line to overlay.
     ax:
         Existing axes to draw on.  If ``None`` a new figure and axes are
         created.
     """
+    if inner_edge is None:
+        inner_edge = kwargs.get("left_edge")
+    if outer_edge is None:
+        outer_edge = kwargs.get("right_edge")
+    if inner_edge is None or outer_edge is None:
+        raise ValueError("Track boundaries must be provided")
+
     if ax is None:
         _, ax = plt.subplots()
 
-    ax.plot(left_edge[:, 0], left_edge[:, 1], "k--", label="Track edge")
-    ax.plot(right_edge[:, 0], right_edge[:, 1], "k--")
+    ax.plot(inner_edge[:, 0], inner_edge[:, 1], "k--", label="Track edge")
+    ax.plot(outer_edge[:, 0], outer_edge[:, 1], "k--")
     ax.plot(x_center, y_center, color="k", label="Centreline")
 
     if x_path is not None and y_path is not None:

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -45,6 +45,7 @@ def run(
     geom = load_track_layout(track_file, ds, closed=closed)
     x, y, psi, kappa_c = geom.x, geom.y, geom.heading, geom.curvature
     left_edge, right_edge = geom.left_edge, geom.right_edge
+    inner_edge, outer_edge = geom.inner_edge, geom.outer_edge
     s = np.arange(x.size) * ds
 
     # Path optimisation
@@ -103,6 +104,10 @@ def run(
             "y_left_m": left_edge[:, 1],
             "x_right_m": right_edge[:, 0],
             "y_right_m": right_edge[:, 1],
+            "x_inner_m": inner_edge[:, 0],
+            "y_inner_m": inner_edge[:, 1],
+            "x_outer_m": outer_edge[:, 0],
+            "y_outer_m": outer_edge[:, 1],
         }
     )
     results_df = pd.DataFrame(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -32,6 +32,8 @@ def test_circle_track_length_and_curvature(tmp_path: Path) -> None:
     length = np.sum(np.hypot(np.diff(np.r_[x, x[0]]), np.diff(np.r_[y, y[0]])))
     assert np.isclose(length, 2 * np.pi * R, atol=1.0)
     assert np.allclose(geom.curvature, 1.0 / R, atol=1e-2)
+    assert np.allclose(geom.inner_edge, geom.left_edge)
+    assert np.allclose(geom.outer_edge, geom.right_edge)
 
 
 def test_right_hand_corner_continuity(tmp_path: Path) -> None:
@@ -59,6 +61,8 @@ def test_right_hand_corner_continuity(tmp_path: Path) -> None:
 
     assert np.isclose(np.linalg.norm(corner_pt - node), 1.0, atol=5e-3)
     assert np.isclose(np.linalg.norm(prev_pt - node), 1.0, atol=5e-3)
+    assert np.allclose(geom.inner_edge[idx], geom.right_edge[idx])
+    assert np.allclose(geom.outer_edge[idx], geom.left_edge[idx])
 
 
 def test_open_track_endpoints_and_length(tmp_path: Path) -> None:
@@ -72,9 +76,16 @@ def test_open_track_endpoints_and_length(tmp_path: Path) -> None:
     df.to_csv(track_file, index=False)
 
     ds = 1.0
-    x, y, heading, curvature, left_edge, right_edge = load_track(
-        str(track_file), ds=ds, closed=False
-    )
+    (
+        x,
+        y,
+        heading,
+        curvature,
+        left_edge,
+        right_edge,
+        inner_edge,
+        outer_edge,
+    ) = load_track(str(track_file), ds=ds, closed=False)
 
     # Start and end points should be distinct for an open track.
     assert not np.allclose([x[0], y[0]], [x[-1], y[-1]])
@@ -85,3 +96,9 @@ def test_open_track_endpoints_and_length(tmp_path: Path) -> None:
     )
     length = np.sum(np.hypot(np.diff(x), np.diff(y))) + ds
     assert np.isclose(length, expected_length, atol=1.0e-6)
+    sign = np.sign(curvature)
+    sign[sign == 0] = 1.0
+    assert np.allclose(inner_edge[sign >= 0], left_edge[sign >= 0])
+    assert np.allclose(inner_edge[sign < 0], right_edge[sign < 0])
+    assert np.allclose(outer_edge[sign >= 0], right_edge[sign >= 0])
+    assert np.allclose(outer_edge[sign < 0], left_edge[sign < 0])

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -33,3 +33,17 @@ def test_one_corner_track_open_track() -> None:
     assert not np.allclose([x[0], y[0]], [x[-1], y[-1]])
     length = geom["s_m"].iloc[-1]
     assert np.isclose(length, 327.0, atol=1e-6)
+    for col in ["x_inner_m", "y_inner_m", "x_outer_m", "y_outer_m"]:
+        assert col in geom.columns
+    idx = np.where(geom["curvature_1pm"].to_numpy() != 0)[0][0]
+    curvature = geom["curvature_1pm"].iloc[idx]
+    inner = geom.loc[idx, ["x_inner_m", "y_inner_m"]].to_numpy()
+    outer = geom.loc[idx, ["x_outer_m", "y_outer_m"]].to_numpy()
+    left = geom.loc[idx, ["x_left_m", "y_left_m"]].to_numpy()
+    right = geom.loc[idx, ["x_right_m", "y_right_m"]].to_numpy()
+    if curvature > 0:
+        assert np.allclose(inner, left)
+        assert np.allclose(outer, right)
+    else:
+        assert np.allclose(inner, right)
+        assert np.allclose(outer, left)


### PR DESCRIPTION
## Summary
- Compute curvature-aware inner and outer track edges and expose them in the TrackGeometry dataclass.
- Include inner/outer edge coordinates in demo geometry CSV output.
- Update plotting helper to accept inner/outer boundaries while keeping left/right aliases.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9211f12a8832a8c877758c5f363a3