### PR TITLE
Include track edges in results output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ columns ``x_m``, ``y_m``, ``section_type`` and ``radius_m`` define the geometry
 while ``width_m`` gives the track width used to compute the left and right
 edges.
 
+Each run writes two CSV files in a time-stamped folder under ``outputs``:
+
+``geometry.csv``
+    Discretised centreline with heading, curvature and track edges.
+``results.csv``
+    Optimised path with speed profile and the same track edges for
+    convenience.
+
 ## License
 
 MIT License (to be defined).

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -6,6 +6,15 @@ Running ``python -m src.run_demo`` executes a simple workflow that
 parses a track layout, optimises a racing line and computes a feasible
 speed profile.  Results are written to time-stamped CSV files under the
 ``outputs`` directory.
+
+Two CSV files are produced for each run:
+
+``geometry.csv``
+    Discretised centreline with heading, curvature and track edge
+    coordinates.
+``results.csv``
+    Optimised path coordinates, speed profile and duplicated track edges
+    for convenience.
 """
 
 from pathlib import Path
@@ -45,7 +54,6 @@ def run(
     geom = load_track_layout(track_file, ds, closed=closed)
     x, y, psi, kappa_c = geom.x, geom.y, geom.heading, geom.curvature
     left_edge, right_edge = geom.left_edge, geom.right_edge
-    inner_edge, outer_edge = geom.inner_edge, geom.outer_edge
     s = np.arange(x.size) * ds
 
     # Path optimisation
@@ -104,10 +112,6 @@ def run(
             "y_left_m": left_edge[:, 1],
             "x_right_m": right_edge[:, 0],
             "y_right_m": right_edge[:, 1],
-            "x_inner_m": inner_edge[:, 0],
-            "y_inner_m": inner_edge[:, 1],
-            "x_outer_m": outer_edge[:, 0],
-            "y_outer_m": outer_edge[:, 1],
         }
     )
     results_df = pd.DataFrame(
@@ -115,6 +119,10 @@ def run(
             "s_m": s,
             "x_path_m": x_path,
             "y_path_m": y_path,
+            "x_left_m": left_edge[:, 0],
+            "y_left_m": left_edge[:, 1],
+            "x_right_m": right_edge[:, 0],
+            "y_right_m": right_edge[:, 1],
             "offset_m": offset,
             "curvature_1pm": kappa_path,
             "speed_mps": v,

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -33,17 +33,8 @@ def test_one_corner_track_open_track() -> None:
     assert not np.allclose([x[0], y[0]], [x[-1], y[-1]])
     length = geom["s_m"].iloc[-1]
     assert np.isclose(length, 327.0, atol=1e-6)
-    for col in ["x_inner_m", "y_inner_m", "x_outer_m", "y_outer_m"]:
+    for col in ["x_left_m", "y_left_m", "x_right_m", "y_right_m"]:
         assert col in geom.columns
-    idx = np.where(geom["curvature_1pm"].to_numpy() != 0)[0][0]
-    curvature = geom["curvature_1pm"].iloc[idx]
-    inner = geom.loc[idx, ["x_inner_m", "y_inner_m"]].to_numpy()
-    outer = geom.loc[idx, ["x_outer_m", "y_outer_m"]].to_numpy()
-    left = geom.loc[idx, ["x_left_m", "y_left_m"]].to_numpy()
-    right = geom.loc[idx, ["x_right_m", "y_right_m"]].to_numpy()
-    if curvature > 0:
-        assert np.allclose(inner, left)
-        assert np.allclose(outer, right)
-    else:
-        assert np.allclose(inner, right)
-        assert np.allclose(outer, left)
+    results = pd.read_csv(out_dir / "results.csv")
+    for col in ["x_left_m", "y_left_m", "x_right_m", "y_right_m"]:
+        assert col in results.columns


### PR DESCRIPTION
## Summary
- drop inner/outer edge usage in demo pipeline
- write left/right track edges to both geometry and results outputs
- document output CSV formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b928a4e6d4832ab6109598d8e913e1