### PR TITLE
Expose path optimisation iteration count

### DIFF
--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -32,7 +32,7 @@ def optimise_lateral_offset(
     buffer: float = 0.0,
     method: str = "SLSQP",
     max_iterations: int | None = None,
-):
+) -> tuple[LateralOffsetSpline, int]:
     """Optimise lateral offset control points for a racing line.
 
     Parameters
@@ -65,8 +65,9 @@ def optimise_lateral_offset(
 
     Returns
     -------
-    LateralOffsetSpline
-        Spline representing the optimised lateral offset ``e(s)``.
+    (LateralOffsetSpline, int)
+        Spline representing the optimised lateral offset ``e(s)`` and the
+        number of iterations performed by the optimiser.
     """
     s = np.asarray(s, dtype=float)
     kappa_c = np.asarray(centreline_curvature, dtype=float)
@@ -125,4 +126,4 @@ def optimise_lateral_offset(
     if not result.success:
         raise RuntimeError("Optimisation failed: " + result.message)
 
-    return LateralOffsetSpline(s_control, result.x)
+    return LateralOffsetSpline(s_control, result.x), int(result.nit)

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -66,7 +66,7 @@ def run(
 
     # Path optimisation
     s_control = np.linspace(s[0], s[-1], n_ctrl)
-    offset_spline = optimise_lateral_offset(
+    offset_spline, opt_iterations = optimise_lateral_offset(
         s,
         kappa_c,
         left_edge,
@@ -75,6 +75,7 @@ def run(
         buffer=buffer,
         max_iterations=max_iter,
     )
+    print(f"Path optimisation: {opt_iterations} iterations")
     offset = offset_spline(s)
     kappa_path = path_curvature(s, offset_spline, kappa_c)
     normal_x = -np.sin(psi)

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -15,10 +15,11 @@ def test_optimisation_respects_bounds():
     s = np.arange(len(geom.x)) * 10.0
     s_control = np.linspace(s[0], s[-1], 8)
 
-    offset = optimise_lateral_offset(
+    offset, iterations = optimise_lateral_offset(
         s, geom.curvature, geom.left_edge, geom.right_edge, s_control, buffer=0.5
     )
 
+    assert iterations > 0
     e_vals = offset(s)
     half_width = 0.5 * np.linalg.norm(geom.left_edge - geom.right_edge, axis=1) - 0.5
 


### PR DESCRIPTION
## Summary
- return both the lateral offset spline and optimiser iteration count from `optimise_lateral_offset`
- log optimiser iterations in `run_demo`
- adjust path optimisation tests for new return type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b936bee80c832a946a57efb522c19b