### PR TITLE
Add lap-time cost option to path optimiser

### DIFF
--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -8,6 +8,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from geometry import load_track_layout
 from path_optim import optimise_lateral_offset
+from path_param import path_curvature
+from speed_solver import solve_speed_profile
 
 
 def test_optimisation_respects_bounds():
@@ -25,3 +27,40 @@ def test_optimisation_respects_bounds():
 
     assert np.all(e_vals <= half_width + 1e-6)
     assert np.all(e_vals >= -half_width - 1e-6)
+
+
+def test_lap_time_cost_reduces_lap_time():
+    geom = load_track_layout("data/oneCornerTrack.csv", ds=10.0)
+    s = np.arange(len(geom.x)) * 10.0
+    s_control = np.linspace(s[0], s[-1], 6)
+
+    mu = 1.0
+    a_wheelie_max = 9.81
+    a_brake = 9.81
+
+    offset_spline, _ = optimise_lateral_offset(
+        s,
+        geom.curvature,
+        geom.left_edge,
+        geom.right_edge,
+        s_control,
+        buffer=0.5,
+        cost="lap_time",
+        mu=mu,
+        a_wheelie_max=a_wheelie_max,
+        a_brake=a_brake,
+        speed_max_iterations=20,
+        v_start=0.0,
+        v_end=0.0,
+    )
+
+    kappa_opt = path_curvature(s, offset_spline, geom.curvature)
+    _, _, _, _, lap_time_opt, _, _ = solve_speed_profile(
+        s, kappa_opt, mu, a_wheelie_max, a_brake, v_start=0.0, v_end=0.0
+    )
+
+    _, _, _, _, lap_time_center, _, _ = solve_speed_profile(
+        s, geom.curvature, mu, a_wheelie_max, a_brake, v_start=0.0, v_end=0.0
+    )
+
+    assert lap_time_opt < lap_time_center


### PR DESCRIPTION
## Summary
- extend `optimise_lateral_offset` with a `cost` switch and speed-solver parameters
- support lap-time minimisation in `run_demo` and CLI via `--cost`
- test lap-time optimisation on a simple one-corner track

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93e89b28c832a954d45ef423027b3