### PR TITLE
Add lap time weighting to path optimisation

### DIFF
--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -44,6 +44,7 @@ def optimise_lateral_offset(
     g: float = 9.81,
     speed_max_iterations: int = 50,
     speed_tol: float = 1e-3,
+    lap_time_weight: float = 1.0,
 ) -> tuple[LateralOffsetSpline, int]:
     """Optimise lateral offset control points for a racing line.
 
@@ -80,6 +81,8 @@ def optimise_lateral_offset(
         Objective to minimise. ``"curvature"`` minimises the integral of the
         squared curvature and its derivative. ``"lap_time"`` minimises the
         lap time computed by :func:`speed_solver.solve_speed_profile`.
+    lap_time_weight:
+        Multiplicative factor applied to the lap time when ``cost='lap_time'``.
     mu, a_wheelie_max, a_brake, v_start, v_end, closed_loop, g, speed_max_iterations, speed_tol:
         Parameters forwarded to :func:`speed_solver.solve_speed_profile` when
         ``cost='lap_time'``.
@@ -152,7 +155,7 @@ def optimise_lateral_offset(
                 max_iterations=speed_max_iterations,
                 tol=speed_tol,
             )
-            return float(lap_time)
+            return float(lap_time_weight * lap_time)
 
     if method == "trust-constr":
         def eval_e(e_ctrl: np.ndarray) -> np.ndarray:

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -52,6 +52,7 @@ def test_lap_time_cost_reduces_lap_time():
         speed_max_iterations=20,
         v_start=0.0,
         v_end=0.0,
+        lap_time_weight=1.0,
     )
 
     kappa_opt = path_curvature(s, offset_spline, geom.curvature)


### PR DESCRIPTION
## Summary
- Allow tuning the lap-time objective via new `lap_time_weight` parameter
- Scale lap-time cost by `lap_time_weight`
- Adjust tests to supply new parameter when using lap-time optimisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b990a1c770832abd06e8a3583b48a2