### PR TITLE
feat: allow custom finite-difference step in path optimisation

### DIFF
--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -34,6 +34,7 @@ def optimise_lateral_offset(
     buffer: float = 0.0,
     method: str = "SLSQP",
     max_iterations: int | None = None,
+    fd_step: float | None = None,
     cost: str = "curvature",
     mu: float = 1.0,
     a_wheelie_max: float = 9.81,
@@ -75,6 +76,11 @@ def optimise_lateral_offset(
     max_iterations:
         Maximum number of iterations for the optimiser. Passed as
         ``maxiter`` in the ``options`` argument to
+        :func:`scipy.optimize.minimize`. If ``None``, SciPy's default is
+        used.
+    fd_step:
+        Step size for the finite-difference gradient approximation passed as
+        ``eps`` in the ``options`` argument to
         :func:`scipy.optimize.minimize`. If ``None``, SciPy's default is
         used.
     cost:
@@ -177,7 +183,14 @@ def optimise_lateral_offset(
 
         constraints = {"type": "ineq", "fun": inequality}
 
-    options = {"maxiter": max_iterations} if max_iterations is not None else None
+    options = {}
+    if max_iterations is not None:
+        options["maxiter"] = max_iterations
+    if fd_step is not None:
+        options["eps"] = fd_step
+    if not options:
+        options = None
+
     result = minimize(
         objective,
         e_init,

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -7,6 +7,7 @@ import numpy as np
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from geometry import load_track_layout
+import path_optim
 from path_optim import optimise_lateral_offset
 from path_param import path_curvature
 from speed_solver import solve_speed_profile
@@ -66,3 +67,33 @@ def test_lap_time_cost_reduces_lap_time():
     )
 
     assert lap_time_opt < lap_time_center
+
+
+def test_fd_step_forwarded_to_minimize(monkeypatch):
+    geom = load_track_layout("data/track_layout.csv", ds=10.0)
+    s = np.arange(len(geom.x)) * 10.0
+    s_control = np.linspace(s[0], s[-1], 8)
+
+    captured: dict | None = None
+
+    def fake_minimize(fun, x0, method=None, constraints=None, options=None):
+        nonlocal captured
+        captured = options
+        class Result:
+            success = True
+            x = x0
+            nit = 0
+        return Result()
+
+    monkeypatch.setattr(path_optim, "minimize", fake_minimize)
+
+    optimise_lateral_offset(
+        s,
+        geom.curvature,
+        geom.left_edge,
+        geom.right_edge,
+        s_control,
+        fd_step=1e-3,
+    )
+
+    assert captured is not None and captured.get("eps") == 1e-3


### PR DESCRIPTION
## Summary
- add optional `fd_step` argument to `optimise_lateral_offset`
- forward `fd_step` to `scipy.optimize.minimize` via `eps` option
- document new parameter and test option forwarding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b992e92360832ab8d9315cc28c726e