### PR TITLE
Limit speed by top-gear RPM

### DIFF
--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -46,3 +46,32 @@ def test_one_corner_track_open_track(capfd) -> None:
     results = pd.read_csv(out_dir / "results.csv")
     for col in ["x_left_m", "y_left_m", "x_right_m", "y_right_m"]:
         assert col in results.columns
+
+
+def test_rpm_capped_top_gear(tmp_path) -> None:
+    """RPM in top gear should not exceed the shift limit."""
+
+    # Create a bike parameter file with a very low shift RPM so that
+    # the unconstrained speed solver would exceed it in top gear.
+    bike_src = Path("data/bike_params_sv650.csv").read_text().splitlines()
+    modified = [
+        "shift_rpm,2000" if line.startswith("shift_rpm") else line
+        for line in bike_src
+    ]
+    bike_file = tmp_path / "bike_params_low_shift.csv"
+    bike_file.write_text("\n".join(modified))
+
+    lap_time, out_dir = run(
+        "data/track_layout.csv",
+        str(bike_file),
+        ds=1.0,
+        buffer=0.5,
+        n_ctrl=20,
+        closed=True,
+    )
+
+    results = pd.read_csv(out_dir / "results.csv")
+    shift_rpm = 2000
+    top_gear = results["gear"].max()
+    rpm_top = results.loc[results["gear"] == top_gear, "rpm"]
+    assert np.all(rpm_top <= shift_rpm)


### PR DESCRIPTION
## Summary
- Compute top-gear maximum speed from drivetrain ratios in demo runner
- Cap speed profile to top-gear limit and recompute acceleration & lap time
- Clip engine RPM to shift RPM and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba415b1c24832aaf6148e3f673dbdb