### PR TITLE
Restore default speed solver tolerance

### DIFF
--- a/src/speed_solver.py
+++ b/src/speed_solver.py
@@ -27,7 +27,7 @@ def solve_speed_profile(
     closed_loop: bool = False,
     g: float = 9.81,
     max_iterations: int = 50,
-    tol: float = 1e-6,  # was 1e-3
+    tol: float = 1e-3,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, int, float]:
     r"""Solve for the feasible speed profile along a path.
 


### PR DESCRIPTION
## Summary
- revert `solve_speed_profile` default tolerance to `1e-3`
- make demo and path optimisation functions only override tolerance when requested

## Testing
- `pytest tests/test_speed_solver.py tests/test_path_optim.py tests/test_run_demo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba43e7bb48832ab6b1120c2a024e5c