### PR TITLE
Restore default lap time weight

### DIFF
--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -45,7 +45,7 @@ def optimise_lateral_offset(
     g: float = 9.81,
     speed_max_iterations: int = 50,
     speed_tol: float | None = None,
-    lap_time_weight: float = 100.0,  # default 1.0
+    lap_time_weight: float = 1.0,
 ) -> tuple[LateralOffsetSpline, int]:
     """Optimise lateral offset control points for a racing line.
 

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -54,7 +54,6 @@ def test_lap_time_cost_reduces_lap_time():
         speed_tol=1e-2,
         v_start=0.0,
         v_end=0.0,
-        lap_time_weight=1.0,
     )
 
     kappa_opt = path_curvature(s, offset_spline, geom.curvature)


### PR DESCRIPTION
## Summary
- revert optimise_lateral_offset's `lap_time_weight` default to 1.0
- rely on default `lap_time_weight` in lap-time optimisation test

## Testing
- `pytest tests/test_path_optim.py::test_lap_time_cost_reduces_lap_time -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba44ab4c94832a94cf166f5324be54