### PR TITLE
Add path optimisation tolerance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Replace `track_layout.csv` and `bike_params_r6.csv` with the desired files. By
 default, the command prints the simulated lap time; pass `--quiet-lap-time` to
 silence this summary output.
 
-The speed profile solver accuracy can be traded for faster execution using
-`--speed-max-iter` and `--speed-tol`. Smaller iteration counts or looser
-convergence tolerances reduce run time but may slightly increase lap time
-estimates.
+The path optimisation and speed profile solver accuracy can be traded for
+faster execution using `--max-iter` and `--path-tol` for the former and
+`--speed-max-iter` and `--speed-tol` for the latter. Smaller iteration counts or
+looser convergence tolerances reduce run time but may slightly increase lap
+time estimates.
 
 The track layout file follows the ``track_layout.csv`` format where each row
 describes the start of either a straight or constant-radius corner section. The

--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -35,6 +35,7 @@ def optimise_lateral_offset(
     method: str = "SLSQP", # SLSQP (default) or trust-constr
     max_iterations: int | None = None,
     fd_step: float | None = None, # default | None = None,
+    path_tol: float = 1e-3,
     cost: str = "curvature",
     mu: float = 1.0,
     a_wheelie_max: float = 9.81,
@@ -83,6 +84,9 @@ def optimise_lateral_offset(
         ``eps`` in the ``options`` argument to
         :func:`scipy.optimize.minimize`. If ``None``, SciPy's default is
         used.
+    path_tol:
+        Convergence tolerance passed as ``tol`` to
+        :func:`scipy.optimize.minimize`.
     cost:
         Objective to minimise. ``"curvature"`` minimises the integral of the
         squared curvature and its derivative. ``"lap_time"`` minimises the
@@ -131,6 +135,7 @@ def optimise_lateral_offset(
                 buffer=buffer,
                 method=method,
                 max_iterations=max_iterations,
+                path_tol=path_tol,
                 cost="curvature",
             )
             e_init = warm_start.e_control
@@ -202,6 +207,7 @@ def optimise_lateral_offset(
         method=method,
         constraints=constraints,
         options=options,
+        tol=path_tol,
     )
 
     if not result.success:

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -43,6 +43,7 @@ def run(
     cost: str = "curvature",
     closed: bool | None = None,
     max_iter: int | None = None,
+    path_tol: float = 1e-3,
     speed_max_iter: int = 50,
     speed_tol: float | None = None,
 ) -> tuple[float, Path]:
@@ -53,9 +54,9 @@ def run(
     cost:
         Objective used for path optimisation. Forwarded to
         :func:`optimise_lateral_offset`.
-    max_iter:
-        Maximum iterations for the path optimisation step. Forwarded to
-        :func:`optimise_lateral_offset`.
+    max_iter, path_tol:
+        Parameters controlling accuracy of the path optimisation step.
+        Forwarded to :func:`optimise_lateral_offset`.
     speed_max_iter, speed_tol:
         Parameters controlling accuracy of the speed profile solver. Smaller
         iteration counts or looser tolerances speed up evaluation but may
@@ -93,6 +94,7 @@ def run(
         s_control,
         buffer=buffer,
         max_iterations=max_iter,
+        path_tol=path_tol,
         cost=cost,
         mu=mu,
         a_wheelie_max=a_wheelie_max,
@@ -230,6 +232,12 @@ def main(argv: list[str] | None = None) -> None:
         help="Maximum iterations for path optimisation",
     )
     parser.add_argument(
+        "--path-tol",
+        type=float,
+        default=1e-3,
+        help="Tolerance for path optimisation",
+    )
+    parser.add_argument(
         "--speed-max-iter",
         type=int,
         default=50,
@@ -279,6 +287,7 @@ def main(argv: list[str] | None = None) -> None:
         cost=args.cost,
         closed=args.closed,
         max_iter=args.max_iter,
+        path_tol=args.path_tol,
         speed_max_iter=args.speed_max_iter,
         speed_tol=args.speed_tol,
     )

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -52,6 +52,7 @@ def test_lap_time_cost_reduces_lap_time():
         a_brake=a_brake,
         speed_max_iterations=20,
         speed_tol=1e-2,
+        path_tol=1e-2,
         v_start=0.0,
         v_end=0.0,
     )
@@ -75,9 +76,9 @@ def test_fd_step_forwarded_to_minimize(monkeypatch):
 
     captured: dict | None = None
 
-    def fake_minimize(fun, x0, method=None, constraints=None, options=None):
+    def fake_minimize(fun, x0, method=None, constraints=None, options=None, tol=None):
         nonlocal captured
-        captured = options
+        captured = {"options": options, "tol": tol}
         class Result:
             success = True
             x = x0
@@ -93,6 +94,8 @@ def test_fd_step_forwarded_to_minimize(monkeypatch):
         geom.right_edge,
         s_control,
         fd_step=1e-3,
+        path_tol=1e-2,
     )
-
-    assert captured is not None and captured.get("eps") == 1e-3
+    assert captured is not None
+    assert captured["options"].get("eps") == 1e-3
+    assert captured["tol"] == 1e-2

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -20,6 +20,8 @@ def test_one_corner_track_open_track(capfd) -> None:
         buffer=0.5,
         n_ctrl=20,
         closed=False,
+        speed_tol=1e-2,
+        path_tol=1e-2,
     )
 
     out = capfd.readouterr().out
@@ -68,6 +70,7 @@ def test_rpm_capped_top_gear(tmp_path) -> None:
         buffer=0.5,
         n_ctrl=20,
         closed=True,
+        path_tol=1e-2,
     )
 
     results = pd.read_csv(out_dir / "results.csv")


### PR DESCRIPTION
## Summary
- support `path_tol` in `optimise_lateral_offset` and CLI demo
- forward tolerance to `scipy.optimize.minimize`
- document and test configuring both `speed_tol` and `path_tol`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4534a884832ab7dd1fbf4575b475