### PR TITLE
Ensure path optimiser respects tolerance and warns on early exit

### DIFF
--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -99,7 +99,8 @@ def test_fd_step_forwarded_to_minimize(monkeypatch):
     )
     # Default should be forwarded as 1e-2
     assert captured and captured[0]["options"].get("eps") == 1e-2
-    assert captured[0]["tol"] == 1e-2
+    assert captured[0]["options"].get("ftol") == 1e-2
+    assert captured[0]["tol"] is None
 
     # Explicit value should override the default
     optimise_lateral_offset(


### PR DESCRIPTION
## Summary
- Default to 100 iterations in `optimise_lateral_offset` and forward `path_tol` via `ftol`
- Warn when the path optimiser terminates in one iteration or less
- Update tests for new tolerance handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba70a96790832abbf14496bdb00287