### PR TITLE
Add iteration check for curvature optimisation

### DIFF
--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -30,6 +30,32 @@ def test_optimisation_respects_bounds():
     assert np.all(e_vals >= -half_width - 1e-6)
 
 
+def test_curvature_cost_performs_multiple_iterations():
+    """Ensure curvature cost optimisation iterates more than once.
+
+    With ``path_tol=1e-6`` on ``track_layout.csv`` the SLSQP solver typically
+    performs around 20 iterations before converging.  The exact count may vary
+    slightly with ``scipy`` versions, but anything less than 2 indicates the
+    optimisation terminated prematurely and warrants investigation."""
+
+    geom = load_track_layout("data/track_layout.csv", ds=10.0)
+    s = np.arange(len(geom.x)) * 10.0
+    s_control = np.linspace(s[0], s[-1], 8)
+
+    _, iterations = optimise_lateral_offset(
+        s,
+        geom.curvature,
+        geom.left_edge,
+        geom.right_edge,
+        s_control,
+        buffer=0.5,
+        cost="curvature",
+        path_tol=1e-6,
+    )
+
+    assert iterations > 1, f"Expected more than one iteration, got {iterations}"
+
+
 def test_lap_time_cost_reduces_lap_time():
     geom = load_track_layout("data/oneCornerTrack.csv", ds=10.0)
     s = np.arange(len(geom.x)) * 10.0


### PR DESCRIPTION
## Summary
- add regression test ensuring `optimise_lateral_offset` with curvature cost performs multiple iterations
- document typical iteration count (~20 for track_layout.csv with path_tol=1e-6) for diagnostic purposes

## Testing
- `pytest tests/test_path_optim.py::test_curvature_cost_performs_multiple_iterations -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba8022e7f8832a89482f40a55bd1ce