### PR TITLE
Tighten path optimisation tolerance defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The path optimisation and speed profile solver accuracy can be traded for
 faster execution using `--max-iter` and `--path-tol` for the former and
 `--speed-max-iter` and `--speed-tol` for the latter. Smaller iteration counts or
 looser convergence tolerances reduce run time but may slightly increase lap
-time estimates.
+time estimates. The path optimiser defaults to a convergence tolerance of
+`1e-6`; relaxing this (for example to `1e-3`) speeds up execution at the cost of
+path accuracy.
 
 By default the path optimiser uses a finite-difference step size of `1e-2` when
 approximating gradients. This value can be adjusted through the `fd_step`

--- a/src/path_optim.py
+++ b/src/path_optim.py
@@ -36,7 +36,7 @@ def optimise_lateral_offset(
     method: str = "SLSQP", # SLSQP (default) or trust-constr
     max_iterations: int | None = None,
     fd_step: float | None = 1e-2,
-    path_tol: float = 1e-3,
+    path_tol: float = 1e-6,
     cost: str = "curvature",
     mu: float = 1.0,
     a_wheelie_max: float = 9.81,

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -43,7 +43,7 @@ def run(
     cost: str = "curvature",
     closed: bool | None = None,
     max_iter: int | None = None,
-    path_tol: float = 1e-3,
+    path_tol: float = 1e-6,
     speed_max_iter: int = 50,
     speed_tol: float | None = None,
 ) -> tuple[float, Path]:
@@ -234,7 +234,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--path-tol",
         type=float,
-        default=1e-3,
+        default=1e-6,
         help="Tolerance for path optimisation",
     )
     parser.add_argument(

--- a/tests/test_path_optim.py
+++ b/tests/test_path_optim.py
@@ -19,7 +19,13 @@ def test_optimisation_respects_bounds():
     s_control = np.linspace(s[0], s[-1], 8)
 
     offset, iterations = optimise_lateral_offset(
-        s, geom.curvature, geom.left_edge, geom.right_edge, s_control, buffer=0.5
+        s,
+        geom.curvature,
+        geom.left_edge,
+        geom.right_edge,
+        s_control,
+        buffer=0.5,
+        path_tol=1e-6,
     )
 
     assert iterations > 0


### PR DESCRIPTION
## Summary
- Reduce default `path_tol` to `1e-6` in `optimise_lateral_offset` for finer path convergence
- Propagate new `path_tol` default through `run_demo` helper and CLI
- Document tighter tolerance trade-offs and update tests to specify the new default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba99addee4832ab91628d5e1b3fa8e