### PR TITLE
Add lean angle and steer rate caps to bike parameter CSVs

### DIFF
--- a/data/bike_params_r6.csv
+++ b/data/bike_params_r6.csv
@@ -18,3 +18,7 @@ gear6,1.150,,
 final_drive,2.9375,,
 eta_driveline,0.95,,
 T_peak,63,,
+phi_max_deg,55
+kappa_dot_max,0.8
+use_lean_angle_cap,true
+use_steer_rate_cap,true

--- a/data/bike_params_sv650.csv
+++ b/data/bike_params_sv650.csv
@@ -18,3 +18,7 @@ gear6,0.851851852
 final_drive,3.214285714
 eta_driveline,0.95
 T_peak,61
+phi_max_deg,55
+kappa_dot_max,0.8
+use_lean_angle_cap,true
+use_steer_rate_cap,true


### PR DESCRIPTION
## Summary
- extend SV650 and R6 bike parameter files with lean angle and steer rate limits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9be3b39c832aad6581ee810ba606