### PR TITLE
Handle boolean and optional vehicle parameters

### DIFF
--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -36,6 +36,50 @@ rpm,Nm
     return file
 
 
+def test_optional_parameter_defaults(tmp_path: Path) -> None:
+    csv_path = _create_csv(tmp_path)
+    vehicle = Vehicle(csv_path)
+    assert vehicle.phi_max_deg is None
+    assert vehicle.kappa_dot_max is None
+    assert vehicle.use_lean_angle_cap is True
+    assert vehicle.use_steer_rate_cap is True
+
+
+def test_optional_parameter_parsing(tmp_path: Path) -> None:
+    content = """
+rho,1.225
+g,9.81
+m,200
+CdA,0.3
+Crr,0.01
+rw,0.3
+mu,1.5
+a_wheelie_max,5.0
+a_brake,9.0
+shift_rpm,10000
+primary,2.0
+gear1,2.0
+final_drive,3.0
+eta_driveline,0.9
+T_peak,50
+phi_max_deg,45
+kappa_dot_max,10.5
+use_lean_angle_cap,FALSE
+use_steer_rate_cap,TrUe
+rpm,Nm
+0,0
+5000,50
+10000,0
+"""
+    file = tmp_path / "bike_params.csv"
+    file.write_text(content.strip())
+    vehicle = Vehicle(file)
+    assert vehicle.phi_max_deg == 45.0
+    assert vehicle.kappa_dot_max == 10.5
+    assert vehicle.use_lean_angle_cap is False
+    assert vehicle.use_steer_rate_cap is True
+
+
 def test_drag_and_rolling(tmp_path: Path) -> None:
     csv_path = _create_csv(tmp_path)
     vehicle = Vehicle(csv_path)


### PR DESCRIPTION
## Summary
- Parse non-numeric parameters as booleans when the CSV uses `true`/`false`
- Expose optional lean and steer rate caps with sensible defaults
- Add tests for parameter parsing and defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d93943c832a9b9cda3c6a2b806e