### PR TITLE
Parse boolean values in bike parameter CSV

### DIFF
--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from io_utils import read_bike_params_csv
+
+
+def test_read_bike_params_csv_bool_and_float() -> None:
+    base_path = Path(__file__).resolve().parents[1]
+    params = read_bike_params_csv(base_path / "data" / "bike_params_r6.csv")
+    assert isinstance(params["mu"], float)
+    assert isinstance(params["use_lean_angle_cap"], bool)
+    assert params["use_lean_angle_cap"] is True
+    assert params["use_steer_rate_cap"] is True


### PR DESCRIPTION
## Summary
- allow boolean entries in motorcycle parameter CSVs
- test parsing of boolean and float values from bike parameter CSV

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e9d0fdc832a862ce45f70b51273