### PR TITLE
Add tests for lean and steer cap defaults

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -96,9 +96,13 @@ def run(
     if kappa_dot_max is None and (val := bike_params.get("kappa_dot_max")) is not None:
         kappa_dot_max = float(val)
     if use_lean_angle_cap is None:
-        use_lean_angle_cap = bool(bike_params.get("use_lean_angle_cap", True))
+        use_lean_angle_cap = bool(
+            bike_params.get("use_lean_angle_cap", phi_max_deg is not None)
+        )
     if use_steer_rate_cap is None:
-        use_steer_rate_cap = bool(bike_params.get("use_steer_rate_cap", True))
+        use_steer_rate_cap = bool(
+            bike_params.get("use_steer_rate_cap", kappa_dot_max is not None)
+        )
 
     # Path optimisation
     s_control = np.linspace(s[0], s[-1], n_ctrl)

--- a/src/vehicle.py
+++ b/src/vehicle.py
@@ -109,8 +109,12 @@ class Vehicle:
         # Optional caps and flags
         self.phi_max_deg = params.get("phi_max_deg")  # None disables cap
         self.kappa_dot_max = params.get("kappa_dot_max")
-        self.use_lean_angle_cap = params.get("use_lean_angle_cap", True)
-        self.use_steer_rate_cap = params.get("use_steer_rate_cap", True)
+        self.use_lean_angle_cap = bool(
+            params.get("use_lean_angle_cap", self.phi_max_deg is not None)
+        )
+        self.use_steer_rate_cap = bool(
+            params.get("use_steer_rate_cap", self.kappa_dot_max is not None)
+        )
 
     # ------------------------------------------------------------------
     # Tractive force computation

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -26,6 +26,8 @@ gear1,2.0
 final_drive,3.0
 eta_driveline,0.9
 T_peak,50
+phi_max_deg,45
+kappa_dot_max,10.5
 rpm,Nm
 0,0
 5000,50
@@ -37,10 +39,41 @@ rpm,Nm
 
 
 def test_optional_parameter_defaults(tmp_path: Path) -> None:
-    csv_path = _create_csv(tmp_path)
-    vehicle = Vehicle(csv_path)
+    content = """
+rho,1.225
+g,9.81
+m,200
+CdA,0.3
+Crr,0.01
+rw,0.3
+mu,1.5
+a_wheelie_max,5.0
+a_brake,9.0
+shift_rpm,10000
+primary,2.0
+gear1,2.0
+final_drive,3.0
+eta_driveline,0.9
+T_peak,50
+rpm,Nm
+0,0
+5000,50
+10000,0
+"""
+    file = tmp_path / "bike_params.csv"
+    file.write_text(content.strip())
+    vehicle = Vehicle(file)
     assert vehicle.phi_max_deg is None
     assert vehicle.kappa_dot_max is None
+    assert vehicle.use_lean_angle_cap is False
+    assert vehicle.use_steer_rate_cap is False
+
+
+def test_optional_parameter_inference(tmp_path: Path) -> None:
+    csv_path = _create_csv(tmp_path)
+    vehicle = Vehicle(csv_path)
+    assert vehicle.phi_max_deg == 45.0
+    assert vehicle.kappa_dot_max == 10.5
     assert vehicle.use_lean_angle_cap is True
     assert vehicle.use_steer_rate_cap is True
 


### PR DESCRIPTION
## Summary
- extend helper CSV in tests with `phi_max_deg` and `kappa_dot_max`
- verify optional cap parsing and default behaviour for lean and steer rate
- infer lean/steer cap defaults based on presence of limits in `Vehicle` and `run_demo`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa452d748832aa8561ee6484127f6