### PR TITLE
Add track column validation to geometry loaders

### DIFF
--- a/src/geometry.py
+++ b/src/geometry.py
@@ -66,6 +66,12 @@ def load_track(file_path: str, ds: float, closed: bool = True) -> TrackGeometry:
         raise ValueError("ds must be positive")
 
     df = pd.read_csv(file_path)
+    required = {"x_m", "y_m", "width_m"}
+    missing = required.difference(df.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"track file missing required columns: {missing_str}")
+
     x = df["x_m"].to_numpy()
     y = df["y_m"].to_numpy()
     width = df["width_m"].to_numpy()
@@ -133,6 +139,12 @@ def load_track_layout(path: str, ds: float, closed: bool = True) -> TrackGeometr
         raise ValueError("ds must be positive")
 
     df = pd.read_csv(path)
+    required = {"x_m", "y_m", "width_m"}
+    missing = required.difference(df.columns)
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(f"track file missing required columns: {missing_str}")
+
     x_nodes = df["x_m"].to_numpy(float)
     y_nodes = df["y_m"].to_numpy(float)
     width_nodes = df["width_m"].to_numpy(float)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 # Ensure src directory on path for test discovery when pytest runs directly
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
@@ -95,3 +96,23 @@ def test_open_track_endpoints_and_length(tmp_path: Path) -> None:
     assert np.isclose(length, expected_length, atol=1.0e-6)
     width = np.linalg.norm(geom.left_edge - geom.right_edge, axis=1)
     assert np.allclose(width, 10.0)
+
+
+def test_load_track_missing_columns(tmp_path: Path) -> None:
+    data = {"x_m": [0.0, 1.0], "y_m": [0.0, 1.0]}
+    df = pd.DataFrame(data)
+    track_file = tmp_path / "missing.csv"
+    df.to_csv(track_file, index=False)
+
+    with pytest.raises(ValueError, match="width_m"):
+        load_track(str(track_file), ds=1.0)
+
+
+def test_load_track_layout_missing_columns(tmp_path: Path) -> None:
+    data = {"x_m": [0.0], "y_m": [0.0], "section_type": ["straight"], "radius_m": [0.0]}
+    df = pd.DataFrame(data)
+    track_file = tmp_path / "missing_layout.csv"
+    df.to_csv(track_file, index=False)
+
+    with pytest.raises(ValueError, match="width_m"):
+        load_track_layout(str(track_file), ds=1.0)


### PR DESCRIPTION
## Summary
- Validate that `x_m`, `y_m` and `width_m` columns exist before loading geometry
- Raise descriptive errors when required track columns are missing
- Add tests covering missing column handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac194d53c832aaf4bbe7946a88cfa