### PR TITLE
Validate drivetrain parameters

### DIFF
--- a/src/drivetrain_utils.py
+++ b/src/drivetrain_utils.py
@@ -28,6 +28,11 @@ def engine_rpm(
     rw:
         Effective wheel radius in metres.
     """
+    if rw <= 0:
+        raise ValueError("wheel radius must be positive")
+    if primary <= 0 or final_drive <= 0 or gear_ratio <= 0:
+        raise ValueError("ratios must be positive")
+
     omega_w = v_mps / rw
     omega_e = omega_w * primary * final_drive * gear_ratio
     return omega_e * 60.0 / (2 * math.pi)
@@ -42,6 +47,10 @@ def select_gear(
     rw: float,
 ) -> float:
     """Return the highest gear ratio that keeps engine RPM below ``shift_rpm``."""
+    if not gears:
+        raise ValueError("gears must be non-empty")
+    if any(g <= 0 for g in gears):
+        raise ValueError("gears must contain only positive ratios")
 
     # ``gears`` is expected to be ordered from lowest to highest gear number
     # (i.e. highest to lowest ratio).  Iterate in this order and select the

--- a/tests/test_drivetrain_utils.py
+++ b/tests/test_drivetrain_utils.py
@@ -77,3 +77,51 @@ def test_select_gear(speed: float, expected_idx: int, expected_rpm: float) -> No
     else:
         assert rpm > params["shift_rpm"]
 
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"rw": 0.0},
+        {"rw": -0.1},
+        {"primary": 0.0},
+        {"final_drive": -1.0},
+        {"gear_ratio": 0.0},
+    ],
+)
+def test_engine_rpm_invalid_arguments(kwargs: dict[str, float]) -> None:
+    params, gears = _load_params()
+    args = dict(
+        v_mps=10.0,
+        primary=params["primary"],
+        final_drive=params["final_drive"],
+        gear_ratio=gears[0],
+        rw=params["rw"],
+    )
+    args.update(kwargs)
+    with pytest.raises(ValueError):
+        engine_rpm(**args)
+
+
+def test_select_gear_invalid_gears() -> None:
+    params, gears = _load_params()
+    with pytest.raises(ValueError):
+        select_gear(
+            10.0,
+            [],
+            params["shift_rpm"],
+            params["primary"],
+            params["final_drive"],
+            params["rw"],
+        )
+    with pytest.raises(ValueError):
+        bad_gears = list(gears)
+        bad_gears[0] = 0.0
+        select_gear(
+            10.0,
+            bad_gears,
+            params["shift_rpm"],
+            params["primary"],
+            params["final_drive"],
+            params["rw"],
+        )
+


### PR DESCRIPTION
## Summary
- validate wheel radius and ratio inputs in `engine_rpm`
- ensure `select_gear` rejects empty or non-positive gear lists
- add tests for invalid drivetrain parameter scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac20aeb78832ab78c1952760759f6