### PR TITLE
Validate iteration parameters and add tests

### DIFF
--- a/src/speed_solver.py
+++ b/src/speed_solver.py
@@ -88,6 +88,11 @@ def solve_speed_profile(
         ``ds / v``, the number of iterations performed and the solver
         runtime ``elapsed_s`` in seconds.
     """
+    if max_iterations <= 0:
+        raise ValueError("max_iterations must be positive")
+    if tol <= 0:
+        raise ValueError("tol must be positive")
+
     s = np.asarray(s, dtype=float)
     kappa = np.asarray(kappa, dtype=float)
     if s.shape != kappa.shape:

--- a/tests/test_speed_solver.py
+++ b/tests/test_speed_solver.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 # Add the ``src`` directory to the import path for test execution.
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
@@ -9,6 +10,34 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from speed_solver import solve_speed_profile
 from geometry import load_track_layout
 from io_utils import read_bike_params_csv
+
+
+def test_invalid_max_iterations_raises() -> None:
+    s = np.array([0.0, 1.0])
+    kappa = np.zeros_like(s)
+    with pytest.raises(ValueError):
+        solve_speed_profile(
+            s,
+            kappa,
+            mu=1.0,
+            a_wheelie_max=9.81,
+            a_brake=11.772,
+            max_iterations=0,
+        )
+
+
+def test_invalid_tol_raises() -> None:
+    s = np.array([0.0, 1.0])
+    kappa = np.zeros_like(s)
+    with pytest.raises(ValueError):
+        solve_speed_profile(
+            s,
+            kappa,
+            mu=1.0,
+            a_wheelie_max=9.81,
+            a_brake=11.772,
+            tol=0.0,
+        )
 
 
 def test_straight_line_profile() -> None:


### PR DESCRIPTION
## Summary
- validate `max_iterations` and `tol` parameters in `solve_speed_profile`
- add tests covering invalid `max_iterations` and `tol`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac3dab8c0832abd0a09e32f2be7f3