### PR TITLE
Drop inner/outer edge aliases from track plotting

### DIFF
--- a/src/plots.py
+++ b/src/plots.py
@@ -21,7 +21,6 @@ def plot_plan_view(
     x_path: Optional[Iterable[float]] = None,
     y_path: Optional[Iterable[float]] = None,
     ax: Optional[plt.Axes] = None,
-    **kwargs,
 ) -> plt.Axes:
     """Plot the track plan view.
 
@@ -31,17 +30,14 @@ def plot_plan_view(
         Coordinates of the track centreline.
     left_edge, right_edge:
         Arrays of shape ``(N, 2)`` giving ``x`` and ``y`` coordinates of the
-        track boundaries.
+        track boundaries.  Both must be provided; the deprecated
+        ``inner_edge``/``outer_edge`` aliases are no longer supported.
     x_path, y_path:
         Optional coordinates of the racing line to overlay.
     ax:
         Existing axes to draw on.  If ``None`` a new figure and axes are
         created.
     """
-    if left_edge is None:
-        left_edge = kwargs.get("inner_edge")
-    if right_edge is None:
-        right_edge = kwargs.get("outer_edge")
     if left_edge is None or right_edge is None:
         raise ValueError("Track boundaries must be provided")
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+# Add the ``src`` directory to the import path for test execution.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from plots import plot_plan_view
+
+
+def _track_data():
+    x_center = np.array([0.0, 1.0])
+    y_center = np.array([0.0, 0.0])
+    left_edge = np.stack((x_center, y_center - 1.0), axis=1)
+    right_edge = np.stack((x_center, y_center + 1.0), axis=1)
+    return x_center, y_center, left_edge, right_edge
+
+
+def test_plot_plan_view_requires_edges():
+    x_center, y_center, left_edge, right_edge = _track_data()
+    with pytest.raises(ValueError):
+        plot_plan_view(x_center, y_center)
+    with pytest.raises(ValueError):
+        plot_plan_view(x_center, y_center, left_edge, None)
+    with pytest.raises(ValueError):
+        plot_plan_view(x_center, y_center, None, right_edge)
+
+
+def test_plot_plan_view_rejects_aliases():
+    x_center, y_center, left_edge, right_edge = _track_data()
+    with pytest.raises(TypeError):
+        plot_plan_view(x_center, y_center, inner_edge=left_edge, outer_edge=right_edge)
+
+
+def test_plot_plan_view_returns_axes():
+    x_center, y_center, left_edge, right_edge = _track_data()
+    ax = plot_plan_view(x_center, y_center, left_edge, right_edge)
+    assert ax.get_xlabel() == "x [m]"
+    plt.close(ax.figure)


### PR DESCRIPTION
## Summary
- simplify `plot_plan_view` by requiring explicit `left_edge`/`right_edge`
- add tests covering required arguments and absence of legacy aliases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac4877000832ab2701f2e672d0156