### PR TITLE
Add CasADi dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 pandas
 matplotlib
 numba
+casadi


### PR DESCRIPTION
## Summary
- add CasADi to Python requirements

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac702ca74832ab61ddbae4d037210