### PR TITLE
feat: add spatial-domain optimal control formulation

### DIFF
--- a/src/method_b/ocp.py
+++ b/src/method_b/ocp.py
@@ -1,87 +1,158 @@
 from __future__ import annotations
 
-"""Definition of a simple optimal control problem for method B.
+"""Optimal control problem definition used by method B.
 
-The :class:`OCP` class bundles symbolic variables, system dynamics, path
-constraints and cost terms used by the collocation-based solver in
-:mod:`src.method_b.solver`.
+This module formulates a simple lap-time minimisation problem in the spatial
+domain.  The independent variable is the arc length ``s`` along a reference
+centre line.  The model is intentionally lightweight but contains the typical
+ingredients required for racing-line optimisation such as friction limits and a
+power envelope.
 """
 
 from dataclasses import dataclass
+from typing import Tuple
 
+import numpy as np
 import casadi as ca
 
 
 @dataclass
 class OCP:
-    """Minimal optimal control problem specification.
+    """Spatial domain optimal control problem for lap-time minimisation."""
 
-    This example problem models a system with three state variables ``x`` and
-    two control inputs ``u``.  The particular dynamics are not intended to be a
-    realistic vehicle model; they merely provide a concrete system to
-    demonstrate the transcription and solver pipeline.
-    """
+    # ------------------------------------------------------------------
+    # Problem parameters
+    kappa_c: float = 0.0
+    """Curvature of the reference centre line (assumed constant)."""
 
-    n_x: int = 3
-    """Number of state variables."""
+    track_half_width: float = 5.0
+    """Half of the track width used for lateral bounds."""
 
+    mu: float = 1.0
+    """Tyre-road friction coefficient."""
+
+    g: float = 9.81
+    """Gravitational acceleration."""
+
+    a_wheelie_max: float = 9.81
+    """Maximum forward acceleration before a wheelie."""
+
+    a_brake: float = 9.81
+    """Maximum braking deceleration before a stoppie."""
+
+    power: float = 100000.0
+    """Available engine power in watts used for the power envelope."""
+
+    mass: float = 200.0
+    """Vehicle mass in kilograms."""
+
+    rho: float = 1.225
+    CdA: float = 0.5
+    Crr: float = 0.015
+
+    phi_max_deg: float | None = None
+    """Optional maximum lean angle in degrees. ``None`` disables this limit."""
+
+    kappa_bounds: Tuple[float, float] = (-0.2, 0.2)
+    """Bounds on curvature state ``kappa``."""
+
+    u_kappa_bounds: Tuple[float, float] = (-0.1, 0.1)
+    """Bounds on curvature rate control ``u_kappa``."""
+
+    w_u_kappa: float = 1e-4
+    """Regularisation weight for curvature rate control."""
+
+    w_a_x: float = 1e-4
+    """Regularisation weight for longitudinal acceleration."""
+
+    # State and control dimensions
+    n_x: int = 4
     n_u: int = 2
-    """Number of control variables."""
 
-    def variables(self) -> tuple[ca.SX, ca.SX]:
+    # ------------------------------------------------------------------
+    # Symbolic variables
+    def variables(self) -> Tuple[ca.SX, ca.SX]:
         """Return symbolic state and control vectors."""
 
         x = ca.SX.sym("x", self.n_x)
         u = ca.SX.sym("u", self.n_u)
         return x, u
 
-    # -- dynamics ---------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Dynamics in the arc-length domain
     def dynamics(self, x: ca.SX, u: ca.SX) -> ca.SX:
-        """Right-hand side of the ODE ``\dot{x} = f(x, u)``.
+        """State derivatives with respect to arc length ``s``."""
 
-        The toy system used here represents a chain of integrators driven by two
-        control inputs interpreted as throttle and brake commands.  The third
-        state is an acceleration-like term actuated by the difference of the
-        controls.  The exact equations are purposely simple as the focus of
-        *method B* is on demonstrating the optimisation workflow rather than the
-        model itself.
-        """
+        e, psi, v, kappa = x[0], x[1], x[2], x[3]
+        u_kappa, a_x = u[0], u[1]
 
-        s, v, a = x[0], x[1], x[2]
-        throttle, brake = u[0], u[1]
+        # Small-angle Frenet relations
+        de_ds = psi
+        dpsi_ds = kappa - self.kappa_c
+        dv_ds = a_x / ca.fmax(v, 1e-3)
+        dkappa_ds = u_kappa
+        return ca.vertcat(de_ds, dpsi_ds, dv_ds, dkappa_ds)
 
-        ds = v
-        dv = a
-        da = throttle - brake
-        return ca.vertcat(ds, dv, da)
+    # ------------------------------------------------------------------
+    # Path constraints
+    def _a_power_max(self, v: ca.SX) -> ca.SX:
+        """Compute speed-dependent acceleration limit from power."""
 
-    # -- path constraints -------------------------------------------------
+        drag = 0.5 * self.rho * self.CdA * v**2
+        rr = self.Crr * self.mass * self.g
+        # P = F * v  =>  a_max = (P/v - drag - rr) / m
+        return self.power / ca.fmax(self.mass * v, 1e-3) - drag / self.mass - rr / self.mass
+
     def path_constraints(self, x: ca.SX, u: ca.SX) -> ca.SX:
-        """Expressions bounded between ``0`` and ``1``.
+        """Return stacked path-constraint expressions."""
 
-        The default problem constrains both control inputs to lie in the range
-        ``[0, 1]`` by returning them as path constraints.
-        """
+        e, _, v, kappa = x[0], x[1], x[2], x[3]
+        a_x = u[1]
 
-        throttle, brake = u[0], u[1]
-        return ca.vertcat(throttle, brake)
+        ay = v**2 * kappa
+        friction = a_x**2 + ay**2
+        power_con = a_x - self._a_power_max(v)
 
-    # -- bounds -----------------------------------------------------------
+        cons = [e, friction, power_con]
+        if self.phi_max_deg is not None:
+            lean = v**2 * ca.fabs(kappa)
+            cons.append(lean)
+
+        return ca.vertcat(*cons)
+
+    # ------------------------------------------------------------------
+    # Bounds for states, controls and path constraints
     def bounds(
         self,
-    ) -> tuple[list[float], list[float], list[float], list[float], list[float], list[float]]:
-        """Bounds for state/control variables and path constraints."""
+    ) -> Tuple[list[float], list[float], list[float], list[float], list[float], list[float]]:
+        e_min = -self.track_half_width
+        e_max = self.track_half_width
 
-        x_min = [-ca.inf, 0.0, -ca.inf]
-        x_max = [ca.inf, ca.inf, ca.inf]
-        u_min = [0.0, 0.0]
-        u_max = [1.0, 1.0]
-        g_min = [0.0, 0.0]
-        g_max = [1.0, 1.0]
+        x_min = [e_min, -ca.inf, 0.0, self.kappa_bounds[0]]
+        x_max = [e_max, ca.inf, ca.inf, self.kappa_bounds[1]]
+
+        u_min = [self.u_kappa_bounds[0], -self.a_brake]
+        u_max = [self.u_kappa_bounds[1], self.a_wheelie_max]
+
+        g_min = [e_min, 0.0, -ca.inf]
+        g_max = [e_max, (self.mu * self.g) ** 2, 0.0]
+
+        if self.phi_max_deg is not None:
+            g_min.append(0.0)
+            g_max.append(self.g * np.tan(np.deg2rad(self.phi_max_deg)))
+
         return x_min, x_max, u_min, u_max, g_min, g_max
 
-    # -- cost -------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Stage cost
     def stage_cost(self, x: ca.SX, u: ca.SX) -> ca.SX:
-        """Quadratic cost on the controls."""
+        """Lap-time objective with control regularisation."""
 
-        return ca.sumsqr(u)
+        v = x[2]
+        u_kappa, a_x = u[0], u[1]
+        inv_v = 1.0 / ca.fmax(v, 1e-3)
+        return inv_v + self.w_u_kappa * u_kappa**2 + self.w_a_x * a_x**2
+
+
+__all__ = ["OCP"]
+


### PR DESCRIPTION
## Summary
- implement racing lap-time OCP with states `(e, psi, v, kappa)` and controls `(u_kappa, a_x)`
- add spatial-domain dynamics, objective, and rich path constraints including friction, power, wheelie/stoppie and lean limits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac8f65cfc832aa2d87269337979aa