### PR TITLE
Add warm-start and slack retry features to Method B solver

### DIFF
--- a/src/method_b/solver.py
+++ b/src/method_b/solver.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 """CasADi-based nonlinear programme builder and solver for method B."""
 
 from dataclasses import dataclass
-from typing import Dict, Any, Optional
+from pathlib import Path
+from typing import Dict, Any, Optional, Union
 
 import numpy as np
 import casadi as ca
@@ -42,9 +43,8 @@ def _build_nlp(
     ocp: OCP,
     grid: np.ndarray,
     slack: bool = False,
-    ipopt_opts: Optional[Dict[str, Any]] = None,
-) -> tuple[ca.Function, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int, int]:
-    """Assemble the CasADi NLP and return solver and bounds."""
+) -> tuple[Dict[str, ca.SX], np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int, int]:
+    """Assemble the CasADi NLP expression and accompanying bounds."""
 
     n_x, n_u = ocp.n_x, ocp.n_u
     x, u, g_defect = trapezoidal_collocation(ocp, grid)
@@ -72,7 +72,6 @@ def _build_nlp(
     ubx = np.concatenate([np.tile(x_max, n_nodes), np.tile(u_max, n_nodes)])
     lbg_defect = np.zeros(n_x * N)
     ubg_defect = np.zeros(n_x * N)
-    g_dim = len(g_min)
     lbg_path = np.tile(g_min, n_nodes)
     ubg_path = np.tile(g_max, n_nodes)
 
@@ -91,13 +90,45 @@ def _build_nlp(
         J += 1e6 * ca.sumsqr(s)
 
     nlp = {"x": z, "f": J, "g": g}
+    return nlp, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u
 
-    opts = {"ipopt.print_level": 0, "print_time": False}
-    if ipopt_opts:
-        opts.update(ipopt_opts)
 
-    solver = ca.nlpsol("solver", "ipopt", nlp, opts)
-    return solver, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u
+def _load_method_a_warm_start(
+    source: Union[str, Path, Dict[str, Any]],
+    n_x: int,
+    n_u: int,
+    n_nodes: int,
+) -> Dict[str, np.ndarray]:
+    """Load warm-start data produced by Method A.
+
+    ``source`` may either be a mapping with the expected arrays or the path to
+    an ``.npz`` file containing them.  Only the keys present are used.  Arrays
+    ``x`` and ``u`` are reshaped and stacked to form an ``x0`` vector compatible
+    with the NLP decision variables.
+    """
+
+    if isinstance(source, (str, bytes, Path)):
+        data = np.load(source, allow_pickle=True)
+        if isinstance(data, np.lib.npyio.NpzFile):
+            data_dict = {k: data[k] for k in data.files}
+        else:  # pragma: no cover - defensive branch
+            data_dict = dict(data)
+    else:
+        data_dict = dict(source)
+
+    warm: Dict[str, np.ndarray] = {}
+    x_guess = data_dict.get("x")
+    u_guess = data_dict.get("u")
+    if x_guess is not None and u_guess is not None:
+        x_guess = np.asarray(x_guess).reshape(n_x, n_nodes)
+        u_guess = np.asarray(u_guess).reshape(n_u, n_nodes)
+        warm["x0"] = np.concatenate([x_guess.reshape(-1), u_guess.reshape(-1)])
+
+    lam_g = data_dict.get("lam_g") or data_dict.get("lam_g0")
+    if lam_g is not None:
+        warm["lam_g0"] = np.asarray(lam_g).reshape(-1)
+
+    return warm
 
 
 # ---------------------------------------------------------------------------
@@ -109,8 +140,13 @@ def solve(
     s_start: float,
     s_end: float,
     n_points: int,
-    warm_start: Optional[Dict[str, np.ndarray]] = None,
-    slack_retry: bool = True,
+    *,
+    warm_start_from_method_a: Union[str, Dict[str, Any], None] = None,
+    use_slacks: bool = False,
+    auto_slack_retry: bool = True,
+    tol: float = 1e-8,
+    print_level: int = 0,
+    linear_solver: str = "mumps",
     ipopt_opts: Optional[Dict[str, Any]] = None,
 ) -> SolverResult:
     """Solve the OCP using trapezoidal collocation and IPOPT.
@@ -121,31 +157,48 @@ def solve(
         Problem definition.
     s_start, s_end, n_points:
         Parameters passed to :func:`create_grid`.
-    warm_start:
-        Optional dictionary containing ``x0`` and ``lam_g0`` initial guesses for
-        the IPOPT solver.
-    slack_retry:
+    warm_start_from_method_a:
+        Either a mapping or a path to data produced by Method A used to
+        initialise the IPOPT solver.
+    use_slacks:
+        If ``True`` slack variables are included from the start.
+    auto_slack_retry:
         If ``True`` the optimisation is automatically retried with slack
-        variables added to the path constraints when the first attempt fails.
+        variables when the first attempt fails.
+    tol, print_level, linear_solver:
+        IPOPT options controlling tolerance, verbosity and the linear solver.
     ipopt_opts:
         Additional IPOPT options overriding the defaults.
     """
 
     grid = create_grid(s_start, s_end, n_points=n_points)
-    solver, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u = _build_nlp(
-        ocp, grid, slack=False, ipopt_opts=ipopt_opts
-    )
+    nlp, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u = _build_nlp(ocp, grid, slack=use_slacks)
 
-    x0 = warm_start.get("x0") if warm_start else None
-    lam_g0 = warm_start.get("lam_g0") if warm_start else None
+    opts: Dict[str, Any] = {
+        "print_time": False,
+        "ipopt.tol": tol,
+        "ipopt.print_level": print_level,
+        "ipopt.linear_solver": linear_solver,
+    }
+    if ipopt_opts:
+        opts.update(ipopt_opts)
+
+    solver = ca.nlpsol("solver", "ipopt", nlp, opts)
+
+    warm: Dict[str, np.ndarray] = {}
+    if warm_start_from_method_a is not None:
+        warm = _load_method_a_warm_start(warm_start_from_method_a, n_x, n_u, n_nodes)
+
+    x0 = warm.get("x0")
+    lam_g0 = warm.get("lam_g0")
+
     sol = solver(lbx=lbx, ubx=ubx, lbg=lbg, ubg=ubg, x0=x0, lam_g0=lam_g0)
     stats = solver.stats()
 
-    if slack_retry and stats.get("return_status") not in {"Solve_Succeeded", "Solved_Succeeded"}:
-        solver, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u = _build_nlp(
-            ocp, grid, slack=True, ipopt_opts=ipopt_opts
-        )
-        sol = solver(lbx=lbx, ubx=ubx, lbg=lbg, ubg=ubg)
+    if (use_slacks or auto_slack_retry) and stats.get("return_status") not in {"Solve_Succeeded", "Solved_Succeeded"}:
+        nlp, lbx, ubx, lbg, ubg, n_nodes, n_x, n_u = _build_nlp(ocp, grid, slack=True)
+        solver = ca.nlpsol("solver", "ipopt", nlp, opts)
+        sol = solver(lbx=lbx, ubx=ubx, lbg=lbg, ubg=ubg, x0=x0, lam_g0=lam_g0)
         stats = solver.stats()
 
     z = np.array(sol["x"]).reshape(-1)


### PR DESCRIPTION
## Summary
- build NLP from transcription outputs in solver
- expose IPOPT options and warm-start from Method A outputs
- retry solve with slack variables when required

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bacad0ba0c832a80764ac02e5db1e3