### PR TITLE
Add Method B plotting labels and output tests

### DIFF
--- a/src/method_b/post.py
+++ b/src/method_b/post.py
@@ -59,8 +59,8 @@ def plot_solution(result: SolverResult) -> None:
     """Create basic plots for the optimised trajectory."""
 
     data = extract_arrays(result)
-    plots.plot_speed_profile(data["s"], data["v"])
-    plots.plot_acceleration_profile(data["s"], data["a_x"], data["a_y"])
+    plots.plot_speed_profile(data["s"], data["v"], label="Method B")
+    plots.plot_acceleration_profile(data["s"], data["a_x"], data["a_y"], label="Method B")
 
 
 def save_outputs(result: SolverResult, timestamp: str | None = None) -> Path:
@@ -83,11 +83,11 @@ def save_outputs(result: SolverResult, timestamp: str | None = None) -> Path:
 
     write_csv(data, out_dir / "solution.csv")
 
-    ax = plots.plot_speed_profile(data["s"], data["v"])
+    ax = plots.plot_speed_profile(data["s"], data["v"], label="Method B")
     ax.figure.savefig(out_dir / "speed_profile.png")
     plt.close(ax.figure)
 
-    ax = plots.plot_acceleration_profile(data["s"], data["a_x"], data["a_y"])
+    ax = plots.plot_acceleration_profile(data["s"], data["a_x"], data["a_y"], label="Method B")
     ax.figure.savefig(out_dir / "acceleration_profile.png")
     plt.close(ax.figure)
 

--- a/src/plots.py
+++ b/src/plots.py
@@ -20,6 +20,7 @@ def plot_plan_view(
     right_edge: np.ndarray | None = None,
     x_path: Optional[Iterable[float]] = None,
     y_path: Optional[Iterable[float]] = None,
+    path_label: str = "Racing line",
     ax: Optional[plt.Axes] = None,
 ) -> plt.Axes:
     """Plot the track plan view.
@@ -49,7 +50,7 @@ def plot_plan_view(
     ax.plot(x_center, y_center, color="k", label="Centreline")
 
     if x_path is not None and y_path is not None:
-        ax.plot(x_path, y_path, color="tab:red", label="Racing line")
+        ax.plot(x_path, y_path, color="tab:red", label=path_label)
 
     ax.set_aspect("equal", adjustable="box")
     ax.set_xlabel("x [m]")
@@ -61,15 +62,18 @@ def plot_plan_view(
 def plot_speed_profile(
     s: Iterable[float],
     speed: Iterable[float],
+    label: str | None = None,
     ax: Optional[plt.Axes] = None,
 ) -> plt.Axes:
     """Plot speed as a function of distance ``s`` along the track."""
     if ax is None:
         _, ax = plt.subplots()
 
-    ax.plot(s, speed, color="tab:blue")
+    ax.plot(s, speed, color="tab:blue", label=label)
     ax.set_xlabel("Distance along track [m]")
     ax.set_ylabel("Speed [m/s]")
+    if label is not None:
+        ax.legend()
     return ax
 
 
@@ -78,13 +82,14 @@ def plot_speed_caps(
     v: Iterable[float],
     v_lean: Iterable[float] | None = None,
     v_steer: Iterable[float] | None = None,
+    label: str = "Speed",
     ax: Optional[plt.Axes] = None,
 ) -> plt.Axes:
     """Overlay speed caps with the final speed profile."""
     if ax is None:
         _, ax = plt.subplots()
 
-    ax.plot(s, v, label="Speed", color="tab:blue")
+    ax.plot(s, v, label=label, color="tab:blue")
 
     if v_lean is not None:
         ax.plot(s, v_lean, label="Lean cap", color="tab:orange", linestyle="--")
@@ -102,14 +107,16 @@ def plot_acceleration_profile(
     s: Iterable[float],
     ax_longitudinal: Iterable[float],
     ay_lateral: Iterable[float],
+    label: str | None = None,
     ax: Optional[plt.Axes] = None,
 ) -> plt.Axes:
     """Plot longitudinal and lateral acceleration versus distance."""
     if ax is None:
         _, ax = plt.subplots()
 
-    ax.plot(s, ax_longitudinal, label="Longitudinal", color="tab:green")
-    ax.plot(s, ay_lateral, label="Lateral", color="tab:orange")
+    suffix = f" ({label})" if label else ""
+    ax.plot(s, ax_longitudinal, label=f"Longitudinal{suffix}", color="tab:green")
+    ax.plot(s, ay_lateral, label=f"Lateral{suffix}", color="tab:orange")
     ax.set_xlabel("Distance along track [m]")
     ax.set_ylabel("Acceleration [m/s$^2$]")
     ax.legend()

--- a/tests/test_method_b_post.py
+++ b/tests/test_method_b_post.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+
+# Ensure the repository root is on the path so ``src`` is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.method_b.solver import SolverResult
+from src.method_b import post
+
+
+def _dummy_result() -> SolverResult:
+    grid = np.array([0.0, 1.0])
+    # States: e, psi, v, kappa
+    x = np.array([
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [1.0, 1.0],
+        [0.0, 0.0],
+    ])
+    # Controls: u_kappa, a_x
+    u = np.zeros((2, 2))
+    return SolverResult(x=x, u=u, grid=grid, stats={})
+
+
+def test_save_outputs_structure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = _dummy_result()
+    out_dir = post.save_outputs(result, timestamp="123")
+    expected = Path("outputs") / "123" / "method_b"
+    assert out_dir == expected
+    assert (out_dir / "solution.csv").is_file()
+    assert (out_dir / "speed_profile.png").is_file()
+    assert (out_dir / "acceleration_profile.png").is_file()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -10,7 +10,7 @@ import pytest
 # Add the ``src`` directory to the import path for test execution.
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from plots import plot_plan_view
+from plots import plot_plan_view, plot_speed_profile, plot_acceleration_profile
 
 
 def _track_data():
@@ -41,4 +41,23 @@ def test_plot_plan_view_returns_axes():
     x_center, y_center, left_edge, right_edge = _track_data()
     ax = plot_plan_view(x_center, y_center, left_edge, right_edge)
     assert ax.get_xlabel() == "x [m]"
+    plt.close(ax.figure)
+
+
+def test_plot_speed_profile_with_label():
+    s = np.linspace(0.0, 1.0, 5)
+    v = np.linspace(0.0, 2.0, 5)
+    ax = plot_speed_profile(s, v, label="Method B")
+    assert ax.get_lines()[0].get_label() == "Method B"
+    plt.close(ax.figure)
+
+
+def test_plot_acceleration_profile_with_label():
+    s = np.linspace(0.0, 1.0, 5)
+    ax_long = np.linspace(0.0, 1.0, 5)
+    ay_lat = np.linspace(0.0, -1.0, 5)
+    ax = plot_acceleration_profile(s, ax_long, ay_lat, label="Method B")
+    labels = [line.get_label() for line in ax.get_lines()]
+    assert "Longitudinal (Method B)" in labels
+    assert "Lateral (Method B)" in labels
     plt.close(ax.figure)


### PR DESCRIPTION
## Summary
- Allow optional labels in plotting helpers so Method B results can be distinguished in legends
- Use the new labels in Method B post-processing and confirm outputs are written under `outputs/<timestamp>/method_b`
- Add tests covering the new plotting labels and verifying the Method B output directory structure

## Testing
- `pytest tests/test_plots.py tests/test_method_b_post.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad01287ac832ab24d149fcfda1a9f