### PR TITLE
Add CI workflow for Method B OCP test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/test_method_b_ocp.py

--- a/tests/test_method_b_ocp.py
+++ b/tests/test_method_b_ocp.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import casadi as ca
+
+# Ensure the repository root is on the path so ``src`` is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.method_b.ocp import OCP
+
+
+def test_variable_shapes():
+    ocp = OCP()
+    x, u = ocp.variables()
+    assert x.size1() == ocp.n_x
+    assert u.size1() == ocp.n_u
+    # Smoke-test casadi by creating a scalar symbol
+    assert isinstance(ca.SX.sym("z"), ca.SX)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies (including casadi) and runs the Method B OCP test
- add basic test for Method B OCP variables and casadi usage

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_method_b_ocp.py`


------
https://chatgpt.com/codex/tasks/task_e_68bad1328638832ab4e93a421e2f4b11