### PR TITLE
Add closed-loop configuration to Method B solver

### DIFF
--- a/run_method_b.py
+++ b/run_method_b.py
@@ -25,6 +25,7 @@ def run(
     ds: float,
     *,
     closed: bool | None = None,
+    closed_loop: bool = True,
     kappa_bounds: Tuple[float, float] = (-0.2, 0.2),
     u_kappa_bounds: Tuple[float, float] = (-0.1, 0.1),
     tol: float = 1e-8,
@@ -46,6 +47,9 @@ def run(
     closed:
         Whether the track should be treated as a closed loop. ``None`` attempts
         to infer this from the CSV data.
+    closed_loop:
+        If ``True`` enforce periodic state continuity. Otherwise the initial
+        state is fixed to zero and the terminal state is free.
     kappa_bounds, u_kappa_bounds:
         Bounds on the curvature state and rate control.
     tol, print_level, linear_solver, ipopt_opts:
@@ -97,6 +101,7 @@ def run(
         s_start,
         s_end,
         n_points,
+        closed_loop=closed_loop,
         warm_start_from_method_a=warm_start,
         use_slacks=use_slacks,
         auto_slack_retry=auto_slack_retry,
@@ -130,6 +135,12 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--warm-start", type=str, default=None, help="Warm start data from Method A")
     parser.add_argument("--use-slacks", action="store_true", help="Include slack variables from the start")
     parser.add_argument("--no-auto-slack", dest="auto_slack_retry", action="store_false", help="Disable automatic slack retry")
+    parser.add_argument(
+        "--closed_loop",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enforce periodic state continuity",
+    )
 
     args = parser.parse_args(argv)
     ipopt_opts = json.loads(args.ipopt_opts) if args.ipopt_opts else None
@@ -148,6 +159,7 @@ def main(argv: list[str] | None = None) -> None:
         warm_start=args.warm_start,
         use_slacks=args.use_slacks,
         auto_slack_retry=args.auto_slack_retry,
+        closed_loop=args.closed_loop,
     )
     print(f"Outputs written to {out_dir}")
 

--- a/tests/test_method_b_solver_boundary.py
+++ b/tests/test_method_b_solver_boundary.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure the repository root is on the path so ``src`` is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.method_b.ocp import OCP
+from src.method_b import solver
+
+
+def test_closed_loop_adds_periodic_constraints():
+    ocp_def = OCP()
+    grid = np.linspace(0.0, 1.0, 5)
+    _, lbx, ubx, lbg, ubg, n_nodes, n_x, _ = solver._build_nlp(
+        ocp_def, grid, closed_loop=True
+    )
+    # Last n_x constraints correspond to periodicity
+    assert np.allclose(lbg[-n_x:], 0.0)
+    assert np.allclose(ubg[-n_x:], 0.0)
+    # Start states are not fixed when closed loop
+    assert not np.allclose(lbx[:n_x], ubx[:n_x])
+
+
+def test_open_loop_fixes_start_states():
+    ocp_def = OCP()
+    grid = np.linspace(0.0, 1.0, 5)
+    _, lbx, ubx, lbg_open, _, _, n_x, _ = solver._build_nlp(
+        ocp_def, grid, closed_loop=False
+    )
+    assert np.allclose(lbx[:n_x], 0.0)
+    assert np.allclose(ubx[:n_x], 0.0)
+    # Open loop omits periodicity constraints
+    _, _, _, lbg_closed, _, _, _, _ = solver._build_nlp(
+        ocp_def, grid, closed_loop=True
+    )
+    assert lbg_closed.size == lbg_open.size + n_x
+


### PR DESCRIPTION
## Summary
- Add `closed_loop` flag and CLI option to `run_method_b.py`
- Enforce periodic state constraints or fixed start conditions in Method B solver
- Cover open vs. closed loop boundary handling with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad3933b30832a85da6c6bd57f46b5