### PR TITLE
Add file-based warm start support

### DIFF
--- a/run_method_b.py
+++ b/run_method_b.py
@@ -96,13 +96,16 @@ def run(
     s_end = ds * (geom.x.size - 1)
     n_points = geom.x.size
 
+    warm_start_path = Path(warm_start) if warm_start else None
+
     result = solver.solve(
         ocp_def,
         s_start,
         s_end,
         n_points,
         closed_loop=closed_loop,
-        warm_start_from_method_a=warm_start,
+        warm_start_from_method_a=warm_start_path is not None,
+        warm_start_file=warm_start_path,
         use_slacks=use_slacks,
         auto_slack_retry=auto_slack_retry,
         tol=tol,

--- a/src/method_b/solver.py
+++ b/src/method_b/solver.py
@@ -140,10 +140,22 @@ def _centreline_initialisation(ocp: OCP, n_nodes: int) -> Dict[str, np.ndarray]:
     return {"x0": x0}
 
 
-def _load_method_a_results(ocp: OCP, grid: np.ndarray) -> Dict[str, np.ndarray]:
-    """Load warm-start data from the latest Method A CSV output."""
+def _load_method_a_results(
+    ocp: OCP, grid: np.ndarray, csv_path: Optional[Path] = None
+) -> Dict[str, np.ndarray]:
+    """Load warm-start data from a Method A CSV output.
 
-    csv_path = _latest_method_a_results()
+    Parameters
+    ----------
+    ocp, grid:
+        Problem definition and discretisation grid.
+    csv_path:
+        Explicit path to a Method A ``results.csv`` file. When ``None`` the
+        latest available output is used.
+    """
+
+    if csv_path is None:
+        csv_path = _latest_method_a_results()
     if csv_path is None:
         return {}
 
@@ -187,6 +199,7 @@ def solve(
     *,
     closed_loop: bool = True,
     warm_start_from_method_a: bool = True,
+    warm_start_file: Optional[Path] = None,
     use_slacks: bool = False,
     auto_slack_retry: bool = True,
     tol: float = 1e-8,
@@ -203,8 +216,11 @@ def solve(
     s_start, s_end, n_points:
         Parameters passed to :func:`create_grid`.
     warm_start_from_method_a:
-        If ``True`` attempt to initialise the solver from the latest Method A
-        outputs.  When ``False`` a simple centreline initialisation is used.
+        If ``True`` attempt to initialise the solver from Method A outputs.
+        When ``False`` a simple centreline initialisation is used.
+    warm_start_file:
+        Optional path to a Method A CSV file used for warm starting when
+        ``warm_start_from_method_a`` is ``True``.
     use_slacks:
         If ``True`` slack variables are included from the start.
     auto_slack_retry:
@@ -233,7 +249,7 @@ def solve(
     solver = ca.nlpsol("solver", "ipopt", nlp, opts)
 
     if warm_start_from_method_a:
-        warm = _load_method_a_results(ocp, grid)
+        warm = _load_method_a_results(ocp, grid, csv_path=warm_start_file)
     else:
         warm = {}
     if not warm:

--- a/tests/test_method_b_solver_warm_start.py
+++ b/tests/test_method_b_solver_warm_start.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+# Ensure the repository root is on the path so ``src`` is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.method_b.ocp import OCP
+from src.method_b import solver
+
+
+def _write_warm_start_csv(path: Path, n: int) -> None:
+    path.write_text(
+        "e,kappa,v,psi\n" + "\n".join(
+            f"{0.1*i},{0.01*i},{1+0.1*i},{0.2*i}" for i in range(n)
+        )
+    )
+
+
+def test_load_method_a_results_from_file(tmp_path):
+    ocp_def = OCP()
+    grid = np.linspace(0.0, 1.0, 5)
+    csv_file = tmp_path / "warm.csv"
+    _write_warm_start_csv(csv_file, grid.size)
+
+    warm = solver._load_method_a_results(ocp_def, grid, csv_file)
+    assert "x0" in warm
+    assert warm["x0"].shape[0] == (ocp_def.n_x + ocp_def.n_u) * grid.size
+
+
+def test_run_passes_warm_start_path(monkeypatch, tmp_path):
+    from run_method_b import run
+
+    csv_file = tmp_path / "ws.csv"
+    csv_file.touch()
+
+    called = {}
+
+    def fake_solve(*args, **kwargs):
+        called.update(kwargs)
+
+        class Dummy:
+            pass
+
+        return Dummy()
+
+    def fake_save(_result):
+        return Path("out")
+
+    monkeypatch.setattr(solver, "solve", fake_solve)
+    monkeypatch.setattr("src.method_b.post.save_outputs", fake_save)
+
+    track_csv = str(Path("data/track_layout.csv"))
+    bike_csv = str(Path("data/bike_params_r6.csv"))
+    run(track_csv, bike_csv, 1.0, warm_start=str(csv_file))
+
+    assert called["warm_start_from_method_a"] is True
+    assert Path(called["warm_start_file"]) == csv_file


### PR DESCRIPTION
## Summary
- allow solver to load warm-start data from an explicit CSV file
- interpret `--warm-start` as a file path and pass separate flag to solver
- test warm start file handling in solver and CLI runner

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbe65e2660832aad85ada9d812d588