### PR TITLE
Support spatial profiles for curvature and width

### DIFF
--- a/run_method_b.py
+++ b/run_method_b.py
@@ -69,12 +69,10 @@ def run(
     geom = load_track_layout(track_csv, ds, closed=closed)
     bike_params = read_bike_params_csv(bike_csv)
 
-    centre = np.column_stack((geom.x, geom.y))
-    left_dist = np.linalg.norm(geom.left_edge - centre, axis=1)
-    right_dist = np.linalg.norm(geom.right_edge - centre, axis=1)
-    track_half_width = float(np.min(np.minimum(left_dist, right_dist)))
+    width = np.linalg.norm(geom.left_edge - geom.right_edge, axis=1)
+    track_half_width = 0.5 * width
 
-    kappa_c = float(np.mean(geom.curvature))
+    kappa_c = geom.curvature
 
     ocp_def = ocp.OCP(
         kappa_c=kappa_c,

--- a/src/method_b/solver.py
+++ b/src/method_b/solver.py
@@ -55,7 +55,7 @@ def _build_nlp(
     N = n_nodes - 1
 
     # Path constraints at each node
-    g_path = [ocp.path_constraints(x[:, k], u[:, k]) for k in range(n_nodes)]
+    g_path = [ocp.path_constraints(x[:, k], u[:, k], k) for k in range(n_nodes)]
     g_path = ca.vertcat(*g_path) if g_path else ca.SX.zeros(0)
 
     # Objective (trapezoidal integration of stage cost)

--- a/src/method_b/transcription.py
+++ b/src/method_b/transcription.py
@@ -82,8 +82,8 @@ def trapezoidal_collocation(ocp: OCP, grid: np.ndarray) -> Tuple[ca.SX, ca.SX, c
         xk1 = x[:, k + 1]
         uk = u[:, k]
         uk1 = u[:, k + 1]
-        fk = ocp.dynamics(xk, uk)
-        fk1 = ocp.dynamics(xk1, uk1)
+        fk = ocp.dynamics(xk, uk, k)
+        fk1 = ocp.dynamics(xk1, uk1, k + 1)
         defect = xk1 - xk - 0.5 * h * (fk + fk1)
         defects.append(defect)
 

--- a/tests/test_method_b_ocp.py
+++ b/tests/test_method_b_ocp.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import casadi as ca
+import numpy as np
 
 # Ensure the repository root is on the path so ``src`` is importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -10,9 +11,11 @@ from src.method_b.ocp import OCP
 
 
 def test_variable_shapes():
-    ocp = OCP()
-    x, u = ocp.variables()
-    assert x.size1() == ocp.n_x
-    assert u.size1() == ocp.n_u
+    kappa = np.zeros(5)
+    width = np.full(5, 5.0)
+    ocp_def = OCP(kappa_c=kappa, track_half_width=width)
+    x, u = ocp_def.variables()
+    assert x.size1() == ocp_def.n_x
+    assert u.size1() == ocp_def.n_u
     # Smoke-test casadi by creating a scalar symbol
     assert isinstance(ca.SX.sym("z"), ca.SX)

--- a/tests/test_method_b_solver_boundary.py
+++ b/tests/test_method_b_solver_boundary.py
@@ -11,8 +11,10 @@ from src.method_b import solver
 
 
 def test_closed_loop_adds_periodic_constraints():
-    ocp_def = OCP()
     grid = np.linspace(0.0, 1.0, 5)
+    kappa = np.zeros_like(grid)
+    width = np.full_like(grid, 5.0)
+    ocp_def = OCP(kappa_c=kappa, track_half_width=width)
     _, lbx, ubx, lbg, ubg, n_nodes, n_x, _ = solver._build_nlp(
         ocp_def, grid, closed_loop=True
     )
@@ -24,8 +26,10 @@ def test_closed_loop_adds_periodic_constraints():
 
 
 def test_open_loop_fixes_start_states():
-    ocp_def = OCP()
     grid = np.linspace(0.0, 1.0, 5)
+    kappa = np.zeros_like(grid)
+    width = np.full_like(grid, 5.0)
+    ocp_def = OCP(kappa_c=kappa, track_half_width=width)
     _, lbx, ubx, lbg_open, _, _, n_x, _ = solver._build_nlp(
         ocp_def, grid, closed_loop=False
     )

--- a/tests/test_method_b_solver_warm_start.py
+++ b/tests/test_method_b_solver_warm_start.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
 
+import sys
+from pathlib import Path
+
 import numpy as np
 
 
@@ -20,8 +23,10 @@ def _write_warm_start_csv(path: Path, n: int) -> None:
 
 
 def test_load_method_a_results_from_file(tmp_path):
-    ocp_def = OCP()
     grid = np.linspace(0.0, 1.0, 5)
+    kappa = np.zeros_like(grid)
+    width = np.full_like(grid, 5.0)
+    ocp_def = OCP(kappa_c=kappa, track_half_width=width)
     csv_file = tmp_path / "warm.csv"
     _write_warm_start_csv(csv_file, grid.size)
 


### PR DESCRIPTION
## Summary
- allow `OCP` to consume curvature and width profiles and use local values in dynamics and path constraints
- pass curvature/width profiles from `run_method_b.run` through the solver/transcription for each grid node
- update solver/transcription/tests for new array-based profiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbe7e57be0832a993657b85586f35d