### PR TITLE
Implement nonlinear Frenet dynamics with regression tests

### DIFF
--- a/src/method_b/ocp.py
+++ b/src/method_b/ocp.py
@@ -151,8 +151,9 @@ class OCP:
 
         kappa_c = self.kappa_c[k] if self.kappa_c.size > 1 else float(self.kappa_c)
 
-        # Small-angle Frenet relations
-        de_ds = psi
+        # Nonlinear Frenet relations with angular wrapping for stability
+        psi_wrapped = ca.atan2(ca.sin(psi), ca.cos(psi))
+        de_ds = ca.sin(psi_wrapped)
         dpsi_ds = kappa - kappa_c
         dv_ds = a_x / ca.fmax(v, self.v_eps)
         dkappa_ds = u_kappa

--- a/tests/test_frenet_dynamics.py
+++ b/tests/test_frenet_dynamics.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import casadi as ca
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.method_b.ocp import OCP
+
+
+def _eval_dynamics(ocp: OCP, x_vals, u_vals, k: int = 0):
+    x = ocp.scale_x(ca.DM(x_vals))
+    u = ca.DM(u_vals)
+    dx_scaled = ocp.dynamics(x, u, k)
+    dx = ocp.unscale_x(dx_scaled)
+    return np.array(dx).squeeze()
+
+
+def test_dynamics_straight_line():
+    ocp = OCP(kappa_c=0.0, track_half_width=5.0)
+    psi = 0.3
+    kappa = 0.1
+    x_vals = [0.0, psi, 10.0, kappa]
+    u_vals = [0.0, 0.0]
+    de_ds, dpsi_ds, *_ = _eval_dynamics(ocp, x_vals, u_vals)
+    assert np.isclose(de_ds, np.sin(psi))
+    assert np.isclose(dpsi_ds, kappa)
+
+
+def test_dynamics_constant_radius_corner():
+    kappa_c = 0.1
+    ocp = OCP(kappa_c=kappa_c, track_half_width=5.0)
+    psi = 0.0
+    e = 0.0
+    v = 10.0
+    kappa = kappa_c
+    x_vals = [e, psi, v, kappa]
+    u_vals = [0.0, 0.0]
+    de_ds, dpsi_ds, *_ = _eval_dynamics(ocp, x_vals, u_vals, k=0)
+    assert np.isclose(de_ds, 0.0)
+    assert np.isclose(dpsi_ds, 0.0)


### PR DESCRIPTION
## Summary
- Replace small-angle Frenet approximation with nonlinear relations using `sin(psi)` and wrapped heading to handle large deviations.
- Add regression tests validating straight-line and constant-radius corner dynamics.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbec357700832a842e3b7bf343f7d2