### PR TITLE
Handle track width and simplify resampling

### DIFF
--- a/speed/tests/test_load_csv_width.py
+++ b/speed/tests/test_load_csv_width.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from speed_profile import load_csv
+
+
+def test_width_column_parsed(tmp_path):
+    p = tmp_path / "track.csv"
+    p.write_text("x_m,y_m,width_m\n0,0,7.5\n1,0,8.5\n")
+    pts = load_csv(str(p))
+    assert [pt.width_m for pt in pts] == [7.5, 8.5]
+
+
+def test_width_defaults_to_zero(tmp_path):
+    p = tmp_path / "track.csv"
+    p.write_text("x_m,y_m\n0,0\n1,0\n")
+    pts = load_csv(str(p))
+    assert [pt.width_m for pt in pts] == [0.0, 0.0]

--- a/speed/tests/test_resample.py
+++ b/speed/tests/test_resample.py
@@ -10,8 +10,7 @@ def _angle_diff(a, b):
     return abs(d)
 
 def test_first_corner_tangent():
-    pts = load_csv("sample_track.csv")
-    csv_path = pathlib.Path(__file__).resolve().parent.parent / "sample_track.csv"
+    csv_path = pathlib.Path(__file__).resolve().parent.parent / "track_layout.csv"
     pts = load_csv(csv_path)
     res = resample(pts, step=5.0)
     idx = next(

--- a/speed/tests/test_step_curvature_consistency.py
+++ b/speed/tests/test_step_curvature_consistency.py
@@ -36,7 +36,7 @@ def _map_indices(src_pts, dst_pts, src_indices):
 
 
 def test_step_curvature_consistency():
-    csv_path = pathlib.Path(__file__).resolve().parent.parent / "sample_track.csv"
+    csv_path = pathlib.Path(__file__).resolve().parent.parent / "track_layout.csv"
     pts = load_csv(csv_path)
     bp = BikeParams()
 


### PR DESCRIPTION
## Summary
- parse optional `width_m` column when loading track CSVs
- simplify path resampling so each row defines the following segment and corners are built from a single radius
- add tests for width parsing and updated corner handling

## Testing
- `pytest -q`
- `pytest speed/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68c232e8dadc832abef70b95dc8473e3