### PR TITLE
Add lean angle and steer rate caps to speed profile CLI

### DIFF
--- a/speed/README.md
+++ b/speed/README.md
@@ -25,6 +25,10 @@ python speed_profile.py input.csv output.csv [options]
 
 * `--step` – resampling distance in metres (default: 2)
 * `--params-file` – load motorcycle and environment parameters from CSV
+* `--phi-max-deg` – maximum lean angle in degrees
+* `--kappa-dot-max` – maximum steer rate in 1/s
+* `--use-lean-angle-cap`/`--no-use-lean-angle-cap` – toggle lean angle cap
+* `--use-steer-rate-cap`/`--no-use-steer-rate-cap` – toggle steer rate cap
 * `--traction-circle` – limit acceleration by lateral grip
 * `--trail-braking` – apply traction limit while braking
 * `--sweeps` – number of forward/backward passes for the solver

--- a/speed/speed_profile.py
+++ b/speed/speed_profile.py
@@ -684,10 +684,34 @@ def main():
     parser.add_argument("--gears", type=str, default=None, help="Comma separated gear ratios")
     parser.add_argument("--eta_driveline", type=float, default=None)
     parser.add_argument("--T_peak", type=float, default=None)
-    parser.add_argument("--phi_max_deg", type=float, default=None)
-    parser.add_argument("--kappa_dot_max", type=float, default=None)
-    parser.add_argument("--use_lean_angle_cap", action="store_true", default=None)
-    parser.add_argument("--use_steer_rate_cap", action="store_true", default=None)
+    parser.add_argument(
+        "--phi-max-deg",
+        dest="phi_max_deg",
+        type=float,
+        default=None,
+        help="Maximum lean angle in degrees",
+    )
+    parser.add_argument(
+        "--kappa-dot-max",
+        dest="kappa_dot_max",
+        type=float,
+        default=None,
+        help="Maximum steer rate in 1/s",
+    )
+    parser.add_argument(
+        "--use-lean-angle-cap",
+        dest="use_lean_angle_cap",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable lean angle speed cap",
+    )
+    parser.add_argument(
+        "--use-steer-rate-cap",
+        dest="use_steer_rate_cap",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable steer rate speed cap",
+    )
 
     parser.add_argument("--traction-circle", action="store_true",
                         help="Enable traction circle for acceleration")


### PR DESCRIPTION
## Summary
- expose `--phi-max-deg` and `--kappa-dot-max` overrides in `speed_profile.py`
- add boolean `--use-lean-angle-cap` and `--use-steer-rate-cap` flags and plumb them into `BikeParams`
- document new options in speed profile README

## Testing
- `pytest`
- `python speed/speed_profile.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c23c6de620832aa6577d5e33f788d1