### PR TITLE
Add open track support for speed profile

### DIFF
--- a/speed/tests/test_open_closed_tracks.py
+++ b/speed/tests/test_open_closed_tracks.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+import math
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from speed_profile import load_csv, resample, compute_speed_profile, BikeParams
+
+
+def test_open_track_start_end_speed_differ():
+    csv_path = pathlib.Path(__file__).resolve().parent.parent / "oneCornerTrack.csv"
+    pts = load_csv(csv_path)
+    pts = resample(pts, step=5.0, closed=False)
+    speeds, _, _, _ = compute_speed_profile(pts, BikeParams(), closed_loop=False)
+    assert not math.isclose(speeds[0], speeds[-1], rel_tol=1e-3)
+
+
+def test_closed_track_start_end_speed_match():
+    csv_path = pathlib.Path(__file__).resolve().parent.parent / "track_layout.csv"
+    pts = load_csv(csv_path)
+    pts = resample(pts, step=5.0, closed=True)
+    speeds, _, _, _ = compute_speed_profile(pts, BikeParams(), closed_loop=True)
+    assert speeds[0] == speeds[-1]
+


### PR DESCRIPTION
## Summary
- allow resampler and speed solver to handle open tracks
- add CLI switch to force open/closed track detection
- test start/end speed behaviour for open and closed tracks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2a99aeba0832a8eb0d7423237ecdf