### PR TITLE
Use sequential gears and cap speed at shift RPM

### DIFF
--- a/speed/tests/test_select_gear.py
+++ b/speed/tests/test_select_gear.py
@@ -6,7 +6,8 @@ from speed_profile import BikeParams, select_gear
 
 
 def _make_bp():
-    return BikeParams(gears=(1.150, 1.286, 1.444, 1.667, 2.0, 2.583))
+    # gear ratios ordered from first to top gear
+    return BikeParams(gears=(2.583, 2.0, 1.667, 1.444, 1.286, 1.150))
 
 
 def test_select_gear_low_speed():

--- a/speed/tests/test_top_speed_limit.py
+++ b/speed/tests/test_top_speed_limit.py
@@ -1,0 +1,30 @@
+import math
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from speed_profile import BikeParams, TrackPoint, compute_speed_profile, max_speed
+
+
+def test_top_speed_limited_by_shift_rpm():
+    bp = BikeParams()
+    bp.mu = 10.0
+    bp.a_wheelie_max = 50.0
+    bp.a_brake = 50.0
+    bp.T_peak = 500.0
+
+    pts = [TrackPoint(i * 10.0, 0.0, "straight", 0.0, 0.0) for i in range(101)]
+    speeds, _, _, _ = compute_speed_profile(
+        pts,
+        bp,
+        sweeps=10,
+        curv_smoothing=0,
+        speed_smoothing=0,
+        phi_max_deg=None,
+        kappa_dot_max=None,
+        use_traction_circle=False,
+        trail_braking=False,
+    )
+    v_top = max_speed(bp)
+    assert max(speeds) <= v_top + 1e-6


### PR DESCRIPTION
## Summary
- select lowest permissible gear and compute maximum speed from shift RPM
- clamp speed profile to top-gear shift speed to prevent unrealistic velocities
- add regression test for RPM-based top speed limit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2b5e2b2c0832aa294912aaef11db8