### PR TITLE
Raise ValueError on mismatched lengths in save_csv

### DIFF
--- a/speed/speed_profile.py
+++ b/speed/speed_profile.py
@@ -97,7 +97,7 @@ def save_csv(
 ) -> None:
     """Save results including curvature, section type and limiting factor."""
     n = len(pts)
-    assert (
+    if not (
         n
         == len(dists)
         == len(speeds)
@@ -105,7 +105,8 @@ def save_csv(
         == len(rpms)
         == len(curvatures)
         == len(limiters)
-    ), "all input lists must have the same length"
+    ):
+        raise ValueError("all input lists must have the same length")
     
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)

--- a/speed/tests/test_save_csv_length.py
+++ b/speed/tests/test_save_csv_length.py
@@ -19,5 +19,5 @@ def test_save_csv_length_mismatch(tmp_path):
     rpms = [1000.0, 2000.0]
     curvatures = [0.0, 0.0]
     limiters = ["limit"]
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         save_csv(tmp_path / "out.csv", pts, dists, speeds, gears, rpms, curvatures, limiters)


### PR DESCRIPTION
## Summary
- validate speed_profile.save_csv input lengths with an explicit ValueError
- update test to expect ValueError on mismatched list lengths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c26c0020832aa86639eb6804f570