### PR TITLE
Remove unused Iterable import from speed profile script

### DIFF
--- a/speed/speed_profile.py
+++ b/speed/speed_profile.py
@@ -17,7 +17,7 @@ options.
 import argparse
 import csv
 from dataclasses import dataclass
-from typing import List, Tuple, Iterable, Optional
+from typing import List, Tuple, Optional
 import math
 import numpy as np
 


### PR DESCRIPTION
## Summary
- remove unused Iterable import from `speed_profile.py`

## Testing
- `python -m compileall -q speed/speed_profile.py`
- `pytest`
- ⚠️ `flake8 speed/speed_profile.py` *(command not found, failed to install flake8 due to proxy restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_68c2c331d644832abfbde9f2782c5671