### PR TITLE
Validate section type when loading track CSV

### DIFF
--- a/speed/speed_profile.py
+++ b/speed/speed_profile.py
@@ -58,9 +58,14 @@ def load_csv(path: str) -> List[TrackPoint]:
         for row in reader:
             if not row:
                 continue
-            section = row.get("section_type", "").strip().lower()
+            raw_section = row.get("section_type", "").strip()
+            section = raw_section.lower()
             if not section:
                 section = "corner"
+            elif section not in ("straight", "corner"):
+                raise ValueError(
+                    f"invalid section_type '{raw_section}' in row {reader.line_num}: {row}"
+                )
             pts.append(
                 TrackPoint(
                     float(row["x_m"]),

--- a/speed/tests/test_load_csv_section_type.py
+++ b/speed/tests/test_load_csv_section_type.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from speed_profile import load_csv
@@ -17,3 +18,18 @@ def test_blank_section_type_defaults_to_corner(tmp_path):
     p.write_text("x_m,y_m,section_type\n0,0,straight\n1,1,\n")
     pts = load_csv(str(p))
     assert [pt.section for pt in pts] == ["straight", "corner"]
+
+
+def test_valid_section_types(tmp_path):
+    p = tmp_path / "track.csv"
+    p.write_text("x_m,y_m,section_type\n0,0,straight\n1,1,corner\n")
+    pts = load_csv(str(p))
+    assert [pt.section for pt in pts] == ["straight", "corner"]
+
+
+def test_invalid_section_type_raises(tmp_path):
+    p = tmp_path / "track.csv"
+    p.write_text("x_m,y_m,section_type\n0,0,straight\n1,1,foo\n")
+    with pytest.raises(ValueError) as excinfo:
+        load_csv(str(p))
+    assert "row 3" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Validate `section_type` values when loading track CSVs and raise helpful errors for invalid entries
- Test valid and invalid `section_type` handling

## Testing
- `pytest speed/tests/test_load_csv_section_type.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c3e67c40832a9bf70b464654fe74