### PR TITLE
Validate resample step size

### DIFF
--- a/speed/speed_profile.py
+++ b/speed/speed_profile.py
@@ -286,6 +286,9 @@ def resample(points: List[TrackPoint], step: float, closed: bool = True) -> List
     point is omitted.
     """
 
+    if step <= 0.0:
+        raise ValueError("step must be positive")
+
     if len(points) < 2:
         return points
 

--- a/speed/tests/test_resample_step.py
+++ b/speed/tests/test_resample_step.py
@@ -1,0 +1,20 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from speed_profile import TrackPoint, resample
+
+
+def _make_points():
+    return [
+        TrackPoint(0.0, 0.0, "straight", 0.0, 0.0),
+        TrackPoint(1.0, 0.0, "straight", 0.0, 0.0),
+    ]
+
+
+@pytest.mark.parametrize("bad_step", [0.0, -1.0])
+def test_resample_invalid_step(bad_step):
+    pts = _make_points()
+    with pytest.raises(ValueError, match="step must be positive"):
+        resample(pts, step=bad_step)


### PR DESCRIPTION
## Summary
- ensure `resample` rejects zero or negative step sizes
- add tests covering invalid `step` values

## Testing
- `pytest speed/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c46eac9c832aba5a596c9e107ade