### PR TITLE
Add optional clothoid racing line

### DIFF
--- a/src/clothoid_path.py
+++ b/src/clothoid_path.py
@@ -93,8 +93,8 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
     Returns
     -------
     (numpy.ndarray, numpy.ndarray)
-        Arrays of arc length ``s`` and curvature ``kappa`` along the constructed
-        racing line.
+        Arrays of lateral offset ``e`` and curvature ``kappa`` along the
+        constructed racing line.
     """
 
     x = np.asarray(track.x, dtype=float)
@@ -112,9 +112,10 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
 
     # If the track has no corners the racing line follows the centreline.
     if not corners:
-        spline = LateralOffsetSpline(s, np.zeros_like(s))
+        e = np.zeros_like(s)
+        spline = LateralOffsetSpline(s, e)
         kappa = path_curvature(s, spline, kappa_c)
-        return s, kappa
+        return e, kappa
 
     width = np.linalg.norm(track.left_edge - track.right_edge, axis=1)
     e = np.zeros(n)
@@ -158,7 +159,7 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
 
     spline = LateralOffsetSpline(s, e)
     kappa = path_curvature(s, spline, kappa_c)
-    return s, kappa
+    return e, kappa
 
 
 # Provide an alias with a more descriptive name.

--- a/tests/test_clothoid_path.py
+++ b/tests/test_clothoid_path.py
@@ -28,9 +28,11 @@ def test_clothoid_path_speed_profile(tmp_path: Path) -> None:
     )
 
     geom = load_track_layout(track_csv, ds=1.0, closed=False)
-    s, kappa = build_clothoid_path(geom)
+    offset, kappa = build_clothoid_path(geom)
     assert geom.apex_fraction is not None
     assert np.nanmax(geom.apex_fraction) == 0.5
+
+    s = np.arange(offset.size) * 1.0
 
     params = read_bike_params_csv(Path(__file__).resolve().parents[1] / "data" / "bike_params_r6.csv")
     v, ax, ay, limit, lap_time, iterations, elapsed_s = solve_speed_profile(


### PR DESCRIPTION
## Summary
- allow `run_demo` to generate a heuristic clothoid racing line via new `--clothoid` flag
- expose `use_clothoid` in `run()` and streamline output messaging
- have `build_clothoid_path` return lateral offset and curvature; update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c54a8f2678832aa9e26238d1688732