### PR TITLE
Return arc length from clothoid path

### DIFF
--- a/src/clothoid_path.py
+++ b/src/clothoid_path.py
@@ -81,7 +81,7 @@ def _hermite_step(u: np.ndarray) -> np.ndarray:
     return 3.0 * u**2 - 2.0 * u**3
 
 
-def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
+def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Construct a simple clothoid racing line for ``track``.
 
     Parameters
@@ -92,9 +92,9 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
 
     Returns
     -------
-    (numpy.ndarray, numpy.ndarray)
-        Arrays of lateral offset ``e`` and curvature ``kappa`` along the
-        constructed racing line.
+    (numpy.ndarray, numpy.ndarray, numpy.ndarray)
+        Arrays of arc length ``s``, lateral offset ``e`` and curvature
+        ``kappa`` along the constructed racing line.
     """
 
     x = np.asarray(track.x, dtype=float)
@@ -115,7 +115,7 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
         e = np.zeros_like(s)
         spline = LateralOffsetSpline(s, e)
         kappa = path_curvature(s, spline, kappa_c)
-        return e, kappa
+        return s, e, kappa
 
     width = np.linalg.norm(track.left_edge - track.right_edge, axis=1)
     e = np.zeros(n)
@@ -159,10 +159,10 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
 
     spline = LateralOffsetSpline(s, e)
     kappa = path_curvature(s, spline, kappa_c)
-    return e, kappa
+    return s, e, kappa
 
 
 # Provide an alias with a more descriptive name.
-def build_racing_line(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray]:
+def build_racing_line(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     return build_clothoid_path(track)
 

--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -114,7 +114,7 @@ def run(
 
     # Path generation
     if use_clothoid:
-        offset, kappa_path = build_clothoid_path(geom)
+        s, offset, kappa_path = build_clothoid_path(geom)
     else:
         s_control = np.linspace(s[0], s[-1], n_ctrl)
         offset_spline, opt_iterations = optimise_lateral_offset(

--- a/tests/test_clothoid_path.py
+++ b/tests/test_clothoid_path.py
@@ -28,11 +28,9 @@ def test_clothoid_path_speed_profile(tmp_path: Path) -> None:
     )
 
     geom = load_track_layout(track_csv, ds=1.0, closed=False)
-    offset, kappa = build_clothoid_path(geom)
+    s, offset, kappa = build_clothoid_path(geom)
     assert geom.apex_fraction is not None
     assert np.nanmax(geom.apex_fraction) == 0.5
-
-    s = np.arange(offset.size) * 1.0
 
     params = read_bike_params_csv(Path(__file__).resolve().parents[1] / "data" / "bike_params_r6.csv")
     v, ax, ay, limit, lap_time, iterations, elapsed_s = solve_speed_profile(


### PR DESCRIPTION
## Summary
- expose arc-length coordinates from `build_clothoid_path`
- adjust run demo and tests for the new `(s, offset, kappa)` return signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c54bcaaed4832ab5b1e865f5f9d44f