### PR TITLE
Compute true arc length for racing line offsets

### DIFF
--- a/src/clothoid_path.py
+++ b/src/clothoid_path.py
@@ -229,8 +229,19 @@ def build_clothoid_path(track: TrackGeometry) -> Tuple[np.ndarray, np.ndarray, n
 
         kappa[start_idx : apex_idx + 1] = sign * pre
         kappa[apex_idx : end_idx + 1] = sign * post
+    # Reparameterise by the true arc length of the offset path.
+    # The trajectory is defined relative to the centreline by a lateral offset
+    # ``e(s)``. The derivative of the path position with respect to the
+    # centreline arc length is ``(1 - e * kappa_c, e_s)`` in the Frenet frame.
+    # Its Euclidean norm gives the local scaling between centreline and path
+    # arc length.
+    e_s = spline.first_derivative(s)
+    scale = np.sqrt((1.0 - e * kappa_c) ** 2 + e_s**2)
+    s_true = np.zeros_like(s)
+    if len(s) > 1:
+        s_true[1:] = np.cumsum(0.5 * (scale[1:] + scale[:-1]) * np.diff(s))
 
-    return s, e, kappa
+    return s_true, e, kappa
 
 
 # Provide an alias with a more descriptive name.

--- a/tests/test_clothoid_path.py
+++ b/tests/test_clothoid_path.py
@@ -29,6 +29,12 @@ def test_clothoid_path_speed_profile(tmp_path: Path) -> None:
 
     geom = load_track_layout(track_csv, ds=1.0, closed=False)
     s, offset, kappa = build_clothoid_path(geom)
+    # The returned ``s`` should reflect the arc length of the offset path and
+    # therefore differ from the centreline arc length.
+    s_center = np.zeros_like(geom.x)
+    s_center[1:] = np.cumsum(np.hypot(np.diff(geom.x), np.diff(geom.y)))
+    assert not np.isclose(s[-1], s_center[-1])
+
     assert geom.apex_fraction is not None
     assert np.nanmax(geom.apex_fraction) == 0.5
 


### PR DESCRIPTION
## Summary
- compute arc-length along offset racing line by integrating local scaling of centreline
- return this true arc-length parameter from `build_clothoid_path`
- extend tests to verify path arc length differs from centreline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c592f98d94832a84837c375d3321ac