### PR TITLE
Clamp speed cap plots and add limit test

### DIFF
--- a/src/run_demo.py
+++ b/src/run_demo.py
@@ -215,7 +215,13 @@ def run(
         from .plots import plot_speed_caps
         import matplotlib.pyplot as plt
 
-        plot_speed_caps(s, v, v_lean=v_lean_cap, v_steer=v_steer_cap)
+        plot_speed_caps(
+            s,
+            v,
+            v_lean=v_lean_cap,
+            v_steer=v_steer_cap,
+            max_speed_cap=float(v_top),
+        )
         plt.show()
 
     # Write outputs


### PR DESCRIPTION
## Summary
- clip speed cap plots to a configurable maximum and ignore non-finite data points
- expose the max speed cap limit in run_demo using the drivetrain top speed
- add a regression test ensuring the plotted axes respect the configured cap

## Testing
- pytest tests/test_plots.py

------
https://chatgpt.com/codex/tasks/task_e_68de1c7783f4832aa87e8a94373e7c04